### PR TITLE
v0.5.1 — Setup Fix, README Overhaul, Dep Fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,19 @@ npm start                   # Start daemon
 npm run dev                 # Dev mode with watch
 ```
 
+## Version Bumps
+
+All 3 packages are pinned to exact versions of each other and must be bumped together:
+
+| File | Fields to update |
+|------|-----------------|
+| `package.json` (root) | `version` |
+| `packages/core/package.json` | `version` |
+| `packages/proxy/package.json` | `version`, `dependencies.aquaman-core` (exact pin) |
+| `packages/plugin/package.json` | `version`, `peerDependencies.aquaman-proxy` (exact pin) |
+
+All four `version` fields and both cross-package dependency pins must match the new version.
+
 ## Credential Backends
 
 Since the Gateway runs on Unix-like systems, backend choice depends on deployment:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Credential isolation proxy for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞",
   "type": "module",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,6 +12,8 @@ Core credential storage, audit logging, and crypto utilities for [aquaman](https
 
 ## Installation
 
+Installed automatically as a dependency of [`aquaman-proxy`](https://www.npmjs.com/package/aquaman-proxy). For direct use:
+
 ```bash
 npm install aquaman-core
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core credential storage, audit logging, and utilities for aquaman",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -2,40 +2,48 @@
 
 OpenClaw Gateway plugin for [aquaman](https://github.com/tech4242/aquaman) credential isolation.
 
-## What This Is
+## How It Works
 
-`aquaman-plugin` integrates aquaman's credential isolation proxy with the OpenClaw Gateway. When loaded, it routes all LLM and channel API traffic through the aquaman proxy so credentials never enter the Gateway process.
+```
+Agent / OpenClaw Gateway              Aquaman Proxy
+┌──────────────────────┐              ┌──────────────────────┐
+│                      │              │                      │
+│  ANTHROPIC_BASE_URL  │──request────>│  Keychain / 1Pass /  │
+│  = localhost:8081    │              │  Vault / Encrypted   │
+│                      │<─response────│                      │
+│  fetch() interceptor │──channel────>│  + Auth injected:    │
+│  redirects channel   │   traffic    │    header / url-path │
+│  API traffic         │              │    basic / oauth     │
+│                      │              │                      │
+│  No credentials.     │              │                      │
+│  Nothing to steal.   │              │                      │
+└──────────────────────┘              └───┬──────────┬───────┘
+                                         │          │
+                                         │          ▼
+                                         │  ~/.aquaman/audit/
+                                         │  (hash-chained log)
+                                         ▼
+                               api.anthropic.com
+                               api.telegram.org
+                               slack.com/api  ...
+```
 
-## Installation
+This plugin makes the left side work. It routes all LLM and channel API traffic through the aquaman proxy so credentials never enter the Gateway process.
+
+## Quick Start
 
 ```bash
-openclaw plugins install aquaman-plugin
-npm install -g aquaman-proxy
+npm install -g aquaman-proxy              # 1. Install the proxy CLI
+aquaman setup                             # 2. Store keys, install plugin, configure OpenClaw
+aquaman migrate openclaw --auto           # 3. Move existing channel creds to secure store
+openclaw                                  # 4. Proxy starts automatically
 ```
 
-## Configuration
+Troubleshooting: `aquaman doctor`
 
-Add to `~/.openclaw/openclaw.json`:
+## Config Options
 
-```json
-{
-  "plugins": {
-    "entries": {
-      "aquaman-plugin": {
-        "enabled": true,
-        "config": {
-          "mode": "proxy",
-          "backend": "keychain",
-          "services": ["anthropic", "openai"],
-          "proxyPort": 8081
-        }
-      }
-    }
-  }
-}
-```
-
-### Config Options
+`aquaman setup` writes these to `~/.openclaw/openclaw.json` automatically:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -44,51 +52,11 @@ Add to `~/.openclaw/openclaw.json`:
 | `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy |
 | `proxyPort` | `number` | `8081` | Proxy listen port |
 
-> Advanced settings (TLS, audit, vault) are configured in `~/.aquaman/config.yaml`.
-
-## Setup
-
-**1. Add credentials:**
-
-```bash
-aquaman credentials add anthropic api_key
-```
-
-**2. Register a placeholder key with OpenClaw:**
-
-```bash
-mkdir -p ~/.openclaw/agents/main/agent
-cat > ~/.openclaw/agents/main/agent/auth-profiles.json << 'EOF'
-{
-  "version": 1,
-  "profiles": {
-    "anthropic:default": {
-      "type": "api_key",
-      "provider": "anthropic",
-      "key": "aquaman-proxy-managed"
-    }
-  },
-  "order": { "anthropic": ["anthropic:default"] }
-}
-EOF
-```
-
-**3. Launch OpenClaw:**
-
-```bash
-openclaw
-```
-
-The plugin auto-starts the proxy, sets `ANTHROPIC_BASE_URL` to route through it, and intercepts channel API traffic via `globalThis.fetch`.
-
-## How It Works
-
-- **Proxy mode** — Spawns aquaman as a child process. Credentials live in a separate OS process. Even if the agent is compromised, it cannot access keys.
-- **Embedded mode** — Credentials loaded in-process. Simpler setup, less isolation. Good for local development.
+> Advanced settings (TLS, audit, vault) go in `~/.aquaman/config.yaml`.
 
 ## Documentation
 
-See the [main README](https://github.com/tech4242/aquaman#readme) for full documentation, architecture details, and manual testing steps.
+See the [main README](https://github.com/tech4242/aquaman#readme) for architecture, Docker deployment, and manual testing.
 
 ## License
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -24,7 +24,7 @@
   "dependencies": {},
   "peerDependencies": {
     "openclaw": ">=2026.1.0",
-    "aquaman-proxy": ">=0.5.0"
+    "aquaman-proxy": "0.5.1"
   },
   "peerDependenciesMeta": {
     "aquaman-proxy": {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Credential isolation plugin for OpenClaw",
   "type": "module",
   "scripts": {

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,100 +1,87 @@
 # aquaman-proxy
 
-Credential isolation proxy daemon and CLI for [aquaman](https://github.com/tech4242/aquaman).
+Credential isolation proxy and CLI for [aquaman](https://github.com/tech4242/aquaman).
 
-## What This Is
+## How It Works
 
-`aquaman-proxy` is a reverse proxy that intercepts API requests and injects credentials from secure backends. The agent process never sees the actual API keys.
-
-Supports 21 services out of the box with four auth modes: header injection, URL-path rewriting, HTTP Basic, and OAuth client credentials.
-
-## Installation
-
-```bash
-npm install -g aquaman-proxy
 ```
+Agent / OpenClaw Gateway              Aquaman Proxy
+┌──────────────────────┐              ┌──────────────────────┐
+│                      │              │                      │
+│  ANTHROPIC_BASE_URL  │──request────>│  Keychain / 1Pass /  │
+│  = localhost:8081    │              │  Vault / Encrypted   │
+│                      │<─response────│                      │
+│  fetch() interceptor │──channel────>│  + Auth injected:    │
+│  redirects channel   │   traffic    │    header / url-path │
+│  API traffic         │              │    basic / oauth     │
+│                      │              │                      │
+│  No credentials.     │              │                      │
+│  Nothing to steal.   │              │                      │
+└──────────────────────┘              └───┬──────────┬───────┘
+                                         │          │
+                                         │          ▼
+                                         │  ~/.aquaman/audit/
+                                         │  (hash-chained log)
+                                         ▼
+                               api.anthropic.com
+                               api.telegram.org
+                               slack.com/api  ...
+```
+
+This package is the right side. A reverse proxy that intercepts API requests and injects credentials from secure backends. 23 builtin services, four auth modes.
 
 ## Quick Start
 
+With OpenClaw:
+
 ```bash
-aquaman init                              # Create config + generate TLS certs
-aquaman credentials add anthropic api_key # Store credential in vault
-aquaman start                             # Start proxy + launch OpenClaw
+npm install -g aquaman-proxy              # 1. Install
+aquaman setup                             # 2. Store keys, install plugin, configure OpenClaw
+aquaman migrate openclaw --auto           # 3. Move existing channel creds to secure store
+openclaw                                  # 4. Proxy starts automatically via plugin
 ```
 
-## CLI Reference
+Standalone:
 
-**Credentials**
-```
-aquaman credentials add <service> <key>       Add a credential
-aquaman credentials list                      List stored credentials
-aquaman credentials delete <service> <key>    Remove a credential
-```
-
-**Proxy**
-```
-aquaman start [--workspace <path>]            Start proxy + launch OpenClaw
-aquaman daemon                                Run proxy in foreground
-aquaman stop                                  Stop running daemon
-aquaman status                                Show config and proxy status
+```bash
+npm install -g aquaman-proxy
+aquaman init
+aquaman credentials add anthropic api_key
+aquaman daemon
 ```
 
-**Audit**
-```
-aquaman audit tail [-n <count>]               Recent audit entries
-aquaman audit verify                          Verify hash chain integrity
-aquaman audit rotate                          Archive and rotate log
-```
+Troubleshooting: `aquaman doctor`
 
-**Migration**
-```
-aquaman migrate openclaw [--config <path>]    Migrate channel creds from openclaw.json
-                         [--dry-run]          to secure store
-                         [--overwrite]
-```
+## CLI
 
-**Setup & Services**
-```
-aquaman init [--force] [--no-tls]             Initialize config + TLS certs
-aquaman configure [--method env|dotenv|shell-rc]  Generate env config
-aquaman services list [--builtin] [--custom]  List configured services
-aquaman services validate                     Validate services.yaml
-```
+| Command | Description |
+|---------|-------------|
+| `aquaman setup` | Guided onboarding (stores keys, installs plugin) |
+| `aquaman doctor` | Diagnose issues with actionable fixes |
+| `aquaman credentials add <svc> <key>` | Store a credential |
+| `aquaman credentials list` | List stored credentials |
+| `aquaman migrate openclaw --auto` | Migrate plaintext secrets to secure store |
+| `aquaman daemon` | Run proxy in foreground |
+| `aquaman start` | Start proxy + launch OpenClaw |
+| `aquaman stop` | Stop running proxy |
+| `aquaman status` | Show config and proxy status |
+| `aquaman audit tail` | Recent audit entries |
+| `aquaman audit verify` | Verify hash chain integrity |
 
-## Supported Services
+## 23 Builtin Services
 
 | Category | Services |
 |----------|----------|
-| **LLM / AI** | Anthropic, OpenAI, GitHub |
-| **Header auth** | Slack, Discord, Matrix, Mattermost, LINE, Twitch, Telnyx, ElevenLabs, Zalo |
-| **URL-path auth** | Telegram |
-| **HTTP Basic auth** | Twilio, BlueBubbles, Nextcloud Talk |
+| **LLM / AI** | Anthropic, OpenAI, GitHub, xAI, Cloudflare AI Gateway |
+| **Header** | Slack, Discord, Matrix, Mattermost, LINE, Twitch, Telnyx, ElevenLabs, Zalo |
+| **URL-path** | Telegram |
+| **HTTP Basic** | Twilio, BlueBubbles, Nextcloud Talk |
 | **OAuth** | MS Teams, Feishu, Google Chat |
-| **At-rest storage** | Nostr, Tlon |
-
-## Configuration
-
-Standalone config lives at `~/.aquaman/config.yaml`:
-
-```yaml
-credentials:
-  backend: keychain
-  proxyPort: 8081
-  proxiedServices:
-    - anthropic
-    - openai
-  tls:
-    enabled: true
-    autoGenerate: true
-
-audit:
-  enabled: true
-  logDir: ~/.aquaman/audit
-```
+| **At-rest only** | Nostr, Tlon |
 
 ## Documentation
 
-See the [main README](https://github.com/tech4242/aquaman#readme) for full documentation, architecture details, and OpenClaw plugin setup.
+See the [main README](https://github.com/tech4242/aquaman#readme) for architecture, credential backends, Docker deployment, and configuration.
 
 ## License
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-proxy",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Credential isolation proxy daemon for OpenClaw",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   "author": "tech4242",
   "license": "MIT",
   "dependencies": {
-    "aquaman-core": "^0.2.0",
+    "aquaman-core": "^0.5.0",
     "commander": "^12.0.0",
     "yaml": "^2.3.4"
   },

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -36,7 +36,7 @@
   "author": "tech4242",
   "license": "MIT",
   "dependencies": {
-    "aquaman-core": "^0.5.0",
+    "aquaman-core": "0.5.1",
     "commander": "^12.0.0",
     "yaml": "^2.3.4"
   },

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -790,6 +790,15 @@ program
           if (fs.existsSync(pluginSrc)) {
             fs.cpSync(pluginSrc, pluginDest, { recursive: true });
             console.log('  \u2713 Plugin installed to ' + pluginDest);
+          } else if (cliDetected) {
+            // npm install — plugin source not bundled, use openclaw's plugin installer
+            try {
+              const { execSync: execSyncFallback } = await import('node:child_process');
+              execSyncFallback('openclaw plugins install aquaman-plugin', { stdio: 'pipe' });
+              console.log('  \u2713 Plugin installed via openclaw');
+            } catch {
+              console.log('  \u2717 Could not install plugin. Run: openclaw plugins install aquaman-plugin');
+            }
           }
 
           // b. Write/merge openclaw.json


### PR DESCRIPTION
- Fix aquaman setup for npm users: Plugin install now falls back to openclaw plugins install aquaman-plugin when installed globally via npm (previously failed silently)
- Fix aquaman-core dependency: Pinned to exact 0.5.1 (was ^0.2.0, could pull stale core)
- README overhaul: All 3 package READMEs rewritten with quickstart, arch diagram, and aquaman migrate openclaw --auto in the default flow