### PR TITLE
v0.7.1 — Security Hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,19 +115,20 @@ jobs:
           path: |
             /usr/local/lib/node_modules/openclaw
             /usr/local/bin/openclaw
-          key: openclaw-${{ runner.os }}-node24-2026.2.9
+          key: openclaw-${{ runner.os }}-node24-2026.2.15
       - name: Install openclaw
         if: steps.cache-openclaw.outputs.cache-hit != 'true'
-        run: npm install -g openclaw@2026.2.9
+        run: npm install -g openclaw@2026.2.15
       - run: npx vitest run test/e2e/openclaw-plugin.test.ts
 
       - name: Install plugin for security audit
         run: |
+          rm -rf ~/.openclaw/extensions/aquaman-plugin
           mkdir -p ~/.openclaw/extensions/aquaman-plugin
           cp packages/plugin/index.ts ~/.openclaw/extensions/aquaman-plugin/
           cp packages/plugin/package.json ~/.openclaw/extensions/aquaman-plugin/
           cp packages/plugin/openclaw.plugin.json ~/.openclaw/extensions/aquaman-plugin/
-          cp -r packages/plugin/src ~/.openclaw/extensions/aquaman-plugin/src/
+          cp -r packages/plugin/src ~/.openclaw/extensions/aquaman-plugin/src
           cd ~/.openclaw/extensions/aquaman-plugin && npm install --omit=dev --silent
 
       - name: OpenClaw security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,25 @@ jobs:
           cp -r packages/plugin/src ~/.openclaw/extensions/aquaman-plugin/src
           cd ~/.openclaw/extensions/aquaman-plugin && npm install --omit=dev --silent
 
+          # Write openclaw.json with plugin allowlist (but no tools.profile —
+          # that's the operator's choice, not ours to impose)
+          cat > ~/.openclaw/openclaw.json << 'EOF'
+          {
+            "plugins": {
+              "allow": ["aquaman-plugin"],
+              "entries": {
+                "aquaman-plugin": {
+                  "enabled": true,
+                  "config": {
+                    "backend": "encrypted-file",
+                    "services": ["anthropic", "openai"]
+                  }
+                }
+              }
+            }
+          }
+          EOF
+
       - name: OpenClaw security audit
         run: |
           OUTPUT=$(openclaw security audit --deep 2>&1) || true
@@ -144,10 +163,16 @@ jobs:
             exit 0
           fi
 
-          # Allow ONLY dangerous-exec on proxy-manager.ts
+          # Expected findings (not aquaman code issues):
+          # 1. dangerous-exec on proxy-manager.ts — true positive, plugin spawns proxy process
+          # 2. tools_reachable_permissive_policy — environment advisory, not a code vulnerability;
+          #    operator chooses their own tools.profile, aquaman should not force "coding" mode
           UNEXPECTED=$(echo "$AQUAMAN_FINDINGS" \
             | grep -v -e "dangerous-exec.*proxy-manager" \
             | grep -v -e "code_safety.*dangerous code patterns" \
+            | grep -v -e "tools_reachable_permissive_policy" \
+            | grep -v -e "Enabled extension plugins:" \
+            | grep -v -e "permissive tool policy" \
             || true)
 
           if [ -n "$UNEXPECTED" ]; then
@@ -156,4 +181,4 @@ jobs:
             exit 1
           fi
 
-          echo "Only expected finding: dangerous-exec on proxy-manager.ts"
+          echo "Only expected findings: dangerous-exec on proxy-manager.ts, tools_reachable_permissive_policy (env advisory)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,13 @@ OpenClaw 2026.2.6+ includes a code safety scanner that checks plugin files for d
 
 There is no suppression mechanism (no inline annotations, no `.auditignore`). The only fix is to ensure trigger patterns don't co-exist in the same file.
 
-**Current state (v0.7.0, tested through 2026.2.15):** 1 expected finding: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process). 0 env-harvesting findings. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9).
+OpenClaw 2026.2.15+ also reports an environment-level advisory:
+
+- **`tools_reachable_permissive_policy`**: fires when any plugin is enabled and the default tool policy is permissive (no `tools.profile` set). This warns that agents could be prompt-injected into calling plugin tools (like `aquaman_status`) when handling untrusted input. This is the operator's configuration choice — aquaman should NOT force a restrictive profile. The fix is for the operator to set `"tools": { "profile": "coding" }` in `openclaw.json` if their agents handle untrusted input.
+
+There is no suppression mechanism for code findings (no inline annotations, no `.auditignore`). The only fix is to ensure trigger patterns don't co-exist in the same file.
+
+**Current state (v0.7.0, tested through 2026.2.15):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9).
 
 **Mitigations:**
 - `aquaman setup` auto-sets `plugins.allow: ["aquaman-plugin"]` in `openclaw.json` (resolves the `extensions_no_allowlist` audit finding)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ OpenClaw 2026.2.6+ includes a code safety scanner that checks plugin files for d
 
 There is no suppression mechanism (no inline annotations, no `.auditignore`). The only fix is to ensure trigger patterns don't co-exist in the same file.
 
-**Current state (v0.7.0):** 1 expected finding: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process). 0 env-harvesting findings. The scanner in 2026.2.9 recursively scans `src/` and `dist/` subdirectories (older versions only scanned top-level files).
+**Current state (v0.7.0, tested through 2026.2.15):** 1 expected finding: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process). 0 env-harvesting findings. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9).
 
 **Mitigations:**
 - `aquaman setup` auto-sets `plugins.allow: ["aquaman-plugin"]` in `openclaw.json` (resolves the `extensions_no_allowlist` audit finding)
@@ -280,7 +280,8 @@ openclaw plugins install ./packages/plugin
 # 2. Sync after code changes
 cp packages/plugin/package.json ~/.openclaw/extensions/aquaman-plugin/package.json
 cp packages/plugin/index.ts ~/.openclaw/extensions/aquaman-plugin/index.ts
-cp -r packages/plugin/src/ ~/.openclaw/extensions/aquaman-plugin/src/
+rm -rf ~/.openclaw/extensions/aquaman-plugin/src
+cp -r packages/plugin/src ~/.openclaw/extensions/aquaman-plugin/src
 
 # 3. Add test credential (dummy key for testing)
 node -e "

--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ The agent only sees a sentinel hostname (`aquaman.local`). It never sees a key, 
 
 ## Security Audit
 
-`openclaw security audit --deep` will report one `dangerous-exec` finding for the plugin. This is expected — spawning the proxy as a separate process is how aquaman keeps credentials out of the agent. `aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.
+`openclaw security audit --deep` reports two expected findings:
+
+- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the proxy as a separate process. This is how aquaman keeps credentials out of the agent.
+- **`tools_reachable_permissive_policy`** — OpenClaw warns that plugin tools (like `aquaman_status`) are reachable when no restrictive tool profile is set. This is an environment-level advisory about your agent's tool policy, not a vulnerability in aquaman. If your agents handle untrusted input, set `"tools": { "profile": "coding" }` in `openclaw.json` to restrict which tools agents can call.
+
+`aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.
 
 ## Why Aquaman
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Credential isolation proxy for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞",
   "type": "module",

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -62,7 +62,12 @@ Troubleshooting: `aquaman doctor`
 
 ## Security Audit Note
 
-Running `openclaw security audit --deep` will show a `dangerous-exec` finding for this plugin. That's expected — the plugin spawns the aquaman proxy as a separate process, which is the whole point of credential isolation. `aquaman setup` adds the plugin to your `plugins.allow` trust list automatically.
+Running `openclaw security audit --deep` will show two expected findings:
+
+- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the aquaman proxy as a separate process, which is the whole point of credential isolation.
+- **`tools_reachable_permissive_policy`** — advisory that plugin tools are reachable under the default tool policy. This is about your OpenClaw tool profile setting, not about aquaman. Set `"tools": { "profile": "coding" }` in `openclaw.json` if your agents handle untrusted input.
+
+`aquaman setup` adds the plugin to your `plugins.allow` trust list automatically.
 
 ## Documentation
 

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -266,10 +266,11 @@ function ensureAuthProfiles(log: OpenClawPluginApi["logger"]): void {
   }
 
   const dir = path.dirname(profilesPath);
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   fs.writeFileSync(
     profilesPath,
-    JSON.stringify({ version: 1, profiles, order }, null, 2)
+    JSON.stringify({ version: 1, profiles, order }, null, 2),
+    { mode: 0o600 }
   );
   log.info(
     `Generated auth-profiles.json with placeholder keys at ${profilesPath}`

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Credential isolation plugin for OpenClaw",
   "type": "module",
   "scripts": {
@@ -13,6 +13,7 @@
   "keywords": [
     "aquaman",
     "openclaw",
+    "openclaw-plugin",
     "plugin",
     "security",
     "credentials",
@@ -26,7 +27,7 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.0",
-    "aquaman-proxy": "0.7.0"
+    "aquaman-proxy": "0.7.1"
   },
   "peerDependenciesMeta": {
     "aquaman-proxy": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-proxy",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Credential isolation proxy daemon for OpenClaw",
   "type": "module",
   "main": "dist/index.js",
@@ -29,6 +29,7 @@
   "keywords": [
     "aquaman",
     "openclaw",
+    "openclaw-plugin",
     "security",
     "credentials",
     "proxy"

--- a/packages/proxy/src/core/audit/logger.ts
+++ b/packages/proxy/src/core/audit/logger.ts
@@ -77,9 +77,9 @@ export class AuditLogger {
     const archiveDir = path.join(this.logDir, 'archive');
     const integrityDir = path.join(this.logDir, 'integrity');
 
-    fs.mkdirSync(this.logDir, { recursive: true });
-    fs.mkdirSync(archiveDir, { recursive: true });
-    fs.mkdirSync(integrityDir, { recursive: true });
+    fs.mkdirSync(this.logDir, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(archiveDir, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(integrityDir, { recursive: true, mode: 0o700 });
 
     // Recover state from existing log
     await this.recoverState();
@@ -129,7 +129,7 @@ export class AuditLogger {
       try {
         const entry = JSON.parse(line) as AuditEntry;
         // Write to main log
-        fs.appendFileSync(this.currentLogPath, JSON.stringify(entry) + '\n');
+        fs.appendFileSync(this.currentLogPath, JSON.stringify(entry) + '\n', { mode: 0o600 });
         this.lastHash = entry.hash;
         this.entryCount++;
       } catch {
@@ -138,7 +138,7 @@ export class AuditLogger {
     }
 
     // Clear WAL after recovery
-    fs.writeFileSync(this.walPath, '');
+    fs.writeFileSync(this.walPath, '', { mode: 0o600 });
   }
 
   async logToolCall(
@@ -226,15 +226,15 @@ export class AuditLogger {
 
     // Write to WAL first (for crash recovery)
     if (this.walEnabled) {
-      fs.appendFileSync(this.walPath, line);
+      fs.appendFileSync(this.walPath, line, { mode: 0o600 });
     }
 
     // Write to main log
-    fs.appendFileSync(this.currentLogPath, line);
+    fs.appendFileSync(this.currentLogPath, line, { mode: 0o600 });
 
     // Clear WAL entry after successful write
     if (this.walEnabled) {
-      fs.writeFileSync(this.walPath, '');
+      fs.writeFileSync(this.walPath, '', { mode: 0o600 });
     }
 
     this.lastHash = entry.hash;

--- a/packages/proxy/src/core/credentials/backends/onepassword.ts
+++ b/packages/proxy/src/core/credentials/backends/onepassword.ts
@@ -14,6 +14,9 @@ export interface OnePasswordStoreOptions {
 const DEFAULT_VAULT = 'aquaman';
 const ITEM_PREFIX = 'aquaman';
 
+// Metadata key validation: must start with letter, only alphanum/underscore/hyphen
+const SAFE_METADATA_KEY = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
 export class OnePasswordStore implements CredentialStore {
   private vault: string;
   private account?: string;
@@ -151,9 +154,12 @@ export class OnePasswordStore implements CredentialStore {
         '--tags', tags.join(',')
       ];
 
-      // Add metadata as fields
+      // Add metadata as fields (sanitize keys to prevent CLI injection)
       if (metadata) {
         for (const [k, v] of Object.entries(metadata)) {
+          if (!SAFE_METADATA_KEY.test(k)) {
+            throw new Error(`Invalid metadata key "${k}": must match /^[a-zA-Z][a-zA-Z0-9_-]*$/`);
+          }
           createArgs.push(`${k}=${v}`);
         }
       }

--- a/packages/proxy/src/core/utils/config.ts
+++ b/packages/proxy/src/core/utils/config.ts
@@ -148,12 +148,12 @@ function mergeConfig(
 export function ensureConfigDir(): void {
   const configDir = getConfigDir();
   if (!fs.existsSync(configDir)) {
-    fs.mkdirSync(configDir, { recursive: true });
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
   }
 }
 
 export function saveConfig(config: WrapperConfig): void {
   ensureConfigDir();
   const configPath = getConfigPath();
-  fs.writeFileSync(configPath, stringifyYaml(config), 'utf-8');
+  fs.writeFileSync(configPath, stringifyYaml(config), { encoding: 'utf-8', mode: 0o600 });
 }

--- a/test/e2e/cli-doctor.test.ts
+++ b/test/e2e/cli-doctor.test.ts
@@ -120,6 +120,7 @@ describe('aquaman doctor E2E', () => {
       expect(stdout).toContain('Config exists');
       expect(stdout).toContain('Plugin installed');
       expect(stdout).toContain('Plugin configured');
+      expect(stdout).toContain('plugins.allow trust list');
       expect(stdout).toContain('Auth profiles exist');
     }, TEST_TIMEOUT);
   });

--- a/test/e2e/cli-setup.test.ts
+++ b/test/e2e/cli-setup.test.ts
@@ -116,6 +116,7 @@ describe('aquaman setup E2E', () => {
         expect(config.plugins?.entries?.['aquaman-plugin']).toBeDefined();
         expect(config.plugins.entries['aquaman-plugin'].enabled).toBe(true);
         expect(config.plugins.entries['aquaman-plugin'].config.backend).toBeDefined();
+        expect(config.plugins?.allow).toContain('aquaman-plugin');
       }
     }, TEST_TIMEOUT);
 

--- a/test/e2e/openclaw-plugin.test.ts
+++ b/test/e2e/openclaw-plugin.test.ts
@@ -15,10 +15,11 @@ const PLUGIN_SRC = path.resolve(__dirname, '../../packages/plugin');
 
 let testStateDir: string;
 
-// Check if OpenClaw is available via npx
+// Check if OpenClaw is globally installed (not via npx auto-install, which
+// can produce empty output on Linux CI).
 function isOpenClawInstalled(): boolean {
   try {
-    execSync('npx openclaw --version', { stdio: 'pipe' });
+    execSync('openclaw --version', { stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -28,7 +29,7 @@ function isOpenClawInstalled(): boolean {
 // Run openclaw with the temp state dir
 function runOpenClaw(args: string): string {
   const testBinDir = path.join(testStateDir, 'bin');
-  return execSync(`npx openclaw ${args} 2>&1`, {
+  return execSync(`openclaw ${args} 2>&1`, {
     encoding: 'utf-8',
     env: {
       ...process.env,

--- a/test/helpers/temp-env.ts
+++ b/test/helpers/temp-env.ts
@@ -70,6 +70,7 @@ export function createTempEnv(options: TempEnvOptions = {}): TempEnv {
       path.join(openclawDir, 'openclaw.json'),
       JSON.stringify({
         plugins: {
+          allow: ['aquaman-plugin'],
           entries: {
             'aquaman-plugin': {
               enabled: true,

--- a/test/unit/audit/logger.test.ts
+++ b/test/unit/audit/logger.test.ts
@@ -36,6 +36,19 @@ describe('AuditLogger', () => {
       expect(fs.existsSync(path.join(testDir, 'integrity'))).toBe(true);
     });
 
+    it('should create directories with mode 0o700', async () => {
+      const freshDir = path.join(os.tmpdir(), `aquaman-perm-test-${Date.now()}`);
+      try {
+        const freshLogger = createAuditLogger({ logDir: freshDir, enabled: true });
+        await freshLogger.initialize();
+        expect(fs.statSync(freshDir).mode & 0o777).toBe(0o700);
+        expect(fs.statSync(path.join(freshDir, 'archive')).mode & 0o777).toBe(0o700);
+        expect(fs.statSync(path.join(freshDir, 'integrity')).mode & 0o777).toBe(0o700);
+      } finally {
+        fs.rmSync(freshDir, { recursive: true, force: true });
+      }
+    });
+
     it('should recover state from existing log', async () => {
       // Write some entries
       await logger.logToolCall('session1', 'agent1', 'bash', { command: 'ls' });


### PR DESCRIPTION
 ### Security

  - **File permissions**: Config dirs created with `0o700`, config/audit/auth-profiles files with `0o600`
  - **Service name validation**: Daemon rejects path traversal and special characters in service names
  - **TOCTOU socket cleanup**: Replaced `existsSync` + `unlinkSync` with atomic try/catch
  - **UDS umask**: Socket file created with restrictive `umask(0o177)`
  - **1Password metadata sanitization**: Reject malicious metadata keys before passing to `op` CLI
  - **KeePassXC echo suppression**: Master password prompt no longer echoes input

  ### Compatibility

 - Verified against OpenClaw 2026.2.15 (deep scan: 2 expected findings — dangerous-exec on proxy-manager.ts, tools_reachable_permissive_policy env advisory)

  ### Fixes

  - Fixed flaky `hostmap-endpoint` test (stdout line buffering across partial data events)