### PR TITLE
feat: add systemd-creds credential backend (TPM2-backed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ aquaman setup --no-openclaw             # Skip plugin installation
 ```
 
 **What it does:**
-1. Detects platform → picks default backend (macOS=keychain, Linux=encrypted-file)
+1. Detects platform → picks default backend (macOS=keychain, Linux=keychain if libsecret, else systemd-creds if available, else encrypted-file)
 2. Runs `init` internally (creates `~/.aquaman/`, config.yaml, audit dir)
 3. Prompts for Anthropic + OpenAI API keys (interactive) or reads from env vars (non-interactive)
 4. Detects OpenClaw (`~/.openclaw/` or `which openclaw`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The `openclaw.plugin.json` manifest defines `additionalProperties: false` with o
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `backend` | `"keychain"` \| `"1password"` \| `"vault"` \| `"encrypted-file"` \| `"keepassxc"` | `"keychain"` | Credential store |
+| `backend` | `"keychain"` \| `"1password"` \| `"vault"` \| `"encrypted-file"` \| `"keepassxc"` \| `"systemd-creds"` | `"keychain"` | Credential store |
 | `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy |
 
 **Do NOT add extra keys** (like `proxyAutoStart`, `auditEnabled`) to `openclaw.json` — OpenClaw validates against the manifest schema and will reject them. Use `~/.aquaman/config.yaml` for advanced settings.
@@ -273,6 +273,7 @@ Since the Gateway runs on Unix-like systems, backend choice depends on deploymen
 | `keepassxc` | Any (with .kdbx file) | Users with existing KeePass databases |
 | `1password` | Any (via `op` CLI) | Team credential sharing |
 | `vault` | Any (via HTTP API) | Enterprise secrets management |
+| `systemd-creds` | Linux (systemd ≥ 256) | TPM2-backed, no root needed, no master password |
 
 ## Testing the OpenClaw Plugin
 
@@ -484,7 +485,7 @@ Promise.all([
 | File | Purpose |
 |------|---------|
 | `packages/proxy/src/core/credentials/store.ts` | Backend abstraction (keychain, encrypted-file, memory) |
-| `packages/proxy/src/core/credentials/backends/` | 1Password and Vault backend implementations |
+| `packages/proxy/src/core/credentials/backends/` | 1Password, Vault, KeePassXC, and systemd-creds backend implementations |
 | `packages/proxy/src/core/audit/logger.ts` | Hash-chained logging |
 | `packages/proxy/src/daemon.ts` | HTTP proxy server on UDS (header, url-path, basic, oauth auth modes) |
 | `packages/proxy/src/cli/index.ts` | CLI (Commander.js, 18 commands incl. `setup`, `doctor`, `migrate openclaw`) |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ openclaw                                  # proxy starts automatically via plugi
 > `aquaman setup` auto-detects your credential backend. macOS defaults to Keychain,
 > Linux defaults to encrypted file. Override with `--backend`:
 > `aquaman setup --backend keepassxc`
-> Options: `keychain`, `encrypted-file`, `keepassxc`, `1password`, `vault`
+> Options: `keychain`, `encrypted-file`, `keepassxc`, `1password`, `vault`, `systemd-creds`
 
 Existing plaintext credentials are migrated automatically during setup.
 The migration detects credentials from channels (Telegram, Slack, etc.)
@@ -101,8 +101,9 @@ The agent only sees a sentinel hostname (`aquaman.local`). It never sees a key, 
 | `keepassxc` | Existing KeePass users | Set `AQUAMAN_KEEPASS_PASSWORD` or key file |
 | `1password` | Team credential sharing | `brew install 1password-cli && op signin` |
 | `vault` | Enterprise secrets management | Set `VAULT_ADDR` + `VAULT_TOKEN` |
+| `systemd-creds` | Linux with systemd ≥ 256 | TPM2-backed, no root required |
 
-**Important:** `encrypted-file` is a last-resort backend for headless Linux/CI environments without a native keyring. For better security, install `libsecret-1-dev` (for GNOME Keyring) or use 1Password/Vault.
+**Important:** `encrypted-file` is a last-resort backend for headless Linux/CI environments without a native keyring. For better security, install `libsecret-1-dev` (for GNOME Keyring), use `systemd-creds` (Linux with TPM2), or use 1Password/Vault.
 
 ## Security Audit
 

--- a/docs/systemd-creds-backend.md
+++ b/docs/systemd-creds-backend.md
@@ -1,0 +1,107 @@
+# systemd-creds Backend
+
+The `systemd-creds` backend encrypts credentials using Linux's
+[systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html)
+utility, which leverages the system's TPM2 chip (when available) for
+hardware-backed encryption.
+
+## Requirements
+
+- **Linux** with **systemd ≥ 256** (for `--user` support)
+- **No root/sudo required** — uses `systemd-creds --user`
+- TPM2 chip recommended (virtual or physical) but not strictly required
+
+## Setup
+
+```bash
+# Check if systemd-creds --user is available
+systemd-creds --user --version
+
+# Setup aquaman with systemd-creds backend
+aquaman setup --backend systemd-creds
+
+# Add credentials
+aquaman credentials add anthropic api_key
+aquaman credentials add openai api_key
+```
+
+## How It Works
+
+Each credential is stored as a separate `.cred` file in `~/.aquaman/creds.d/`:
+
+```
+~/.aquaman/creds.d/
+  anthropic--api_key.cred    # encrypted with systemd-creds --user
+  openai--api_key.cred
+  github--api_key.cred
+  _index.cred                # encrypted index of all credentials
+```
+
+### Encryption
+
+Credentials are encrypted with `systemd-creds --user encrypt`, which:
+
+1. Uses the per-user credential key (managed by systemd)
+2. Binds to TPM2 when available — secrets can't be decrypted on another machine
+3. Requires no master password — the key is tied to the user session
+
+### In-Memory Caching
+
+Decrypted values are cached in-memory for the lifetime of the aquaman proxy
+process. This means each credential is decrypted at most once per proxy start,
+minimizing overhead.
+
+## Security Properties
+
+| Property | Status |
+|----------|--------|
+| Encryption at rest | ✅ AES-256 via systemd-creds |
+| TPM2 binding | ✅ When TPM2 available |
+| No master password | ✅ Key managed by systemd |
+| Per-user isolation | ✅ Uses `--user` flag |
+| No root required | ✅ Runs as regular user |
+| Survives reboot | ✅ Credentials persist in ~/.aquaman/creds.d/ |
+| Portable to other machines | ❌ By design (TPM-bound) |
+
+## Comparison with encrypted-file
+
+| | `encrypted-file` | `systemd-creds` |
+|---|---|---|
+| Master password | Required (12+ chars) | None |
+| Hardware binding | No | Yes (TPM2) |
+| Portability | Can move between machines | Bound to machine |
+| Root required | No | No |
+| Platform | Any | Linux (systemd ≥ 256) |
+
+## Troubleshooting
+
+### "systemd-creds: command not found"
+
+Install systemd (usually included in all modern Linux distributions).
+
+### "Failed to encrypt/decrypt"
+
+Check that `systemd-creds --user encrypt` works:
+
+```bash
+echo "test" | systemd-creds --user encrypt --name=test - -
+```
+
+If this fails, your systemd version may not support `--user` (requires ≥ 256).
+
+### Adding a vTPM to a VM
+
+If running in a VM without TPM2, add a virtual TPM:
+
+**QEMU/KVM (libvirt):**
+```bash
+sudo dnf install swtpm swtpm-tools  # or apt install
+# Add to VM XML inside <devices>:
+# <tpm model='tpm-crb'>
+#   <backend type='emulator' version='2.0'/>
+# </tpm>
+```
+
+**Proxmox:** Enable TPM in VM hardware settings.
+
+**VirtualBox 7.0+:** Settings → System → Enable TPM 2.0.

--- a/packages/plugin/openclaw.plugin.json
+++ b/packages/plugin/openclaw.plugin.json
@@ -14,7 +14,7 @@
     "properties": {
       "backend": {
         "type": "string",
-        "enum": ["keychain", "1password", "vault", "encrypted-file", "keepassxc"],
+        "enum": ["keychain", "1password", "vault", "encrypted-file", "keepassxc", "systemd-creds"],
         "default": "keychain",
         "description": "Credential storage backend"
       },

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -558,7 +558,7 @@ program
 program
   .command('setup')
   .description('All-in-one setup wizard — creates config, stores credentials, installs plugin')
-  .option('--backend <backend>', 'Credential backend (keychain, encrypted-file, keepassxc, 1password, vault)')
+  .option('--backend <backend>', 'Credential backend (keychain, encrypted-file, keepassxc, 1password, vault, systemd-creds)')
   .option('--no-openclaw', 'Skip OpenClaw plugin installation')
   .option('--non-interactive', 'Use environment variables instead of prompts (for CI)')
   .action(async (options) => {

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -593,19 +593,20 @@ program
       if (platform === 'darwin') {
         backend = 'keychain';
       } else {
-        // Linux: check for libsecret
+        // Linux: check for libsecret first, then systemd-creds, then encrypted-file
         try {
           const { execSync } = await import('node:child_process');
           execSync('pkg-config --exists libsecret-1', { stdio: 'pipe' });
           backend = 'keychain';
         } catch {
-          backend = 'encrypted-file';
+          const { isSystemdCredsAvailable } = await import('../core/credentials/backends/systemd-creds.js');
+          backend = isSystemdCredsAvailable() ? 'systemd-creds' : 'encrypted-file';
         }
       }
     }
 
     // Validate backend
-    const validBackends = ['keychain', 'encrypted-file', 'keepassxc', '1password', 'vault'];
+    const validBackends = ['keychain', 'encrypted-file', 'keepassxc', '1password', 'vault', 'systemd-creds'];
     if (!validBackends.includes(backend)) {
       console.error(`  Invalid backend: ${backend}`);
       console.error(`  Valid options: ${validBackends.join(', ')}`);
@@ -672,6 +673,13 @@ program
           }
           process.env['AQUAMAN_KEEPASS_PASSWORD'] = password.trim();
         }
+      }
+    } else if (backend === 'systemd-creds') {
+      const { isSystemdCredsAvailable } = await import('../core/credentials/backends/systemd-creds.js');
+      if (!isSystemdCredsAvailable()) {
+        console.error('  systemd-creds backend requires systemd-creds with --user support (systemd >= 256).');
+        console.error('  Try: systemd-creds --version');
+        process.exit(1);
       }
     }
 
@@ -964,6 +972,14 @@ program
     let store: import('../core/index.js').CredentialStore | null = null;
     try {
       config = loadConfig();
+
+      if (config.credentials.backend === 'systemd-creds') {
+        const { isSystemdCredsAvailable } = await import('../core/credentials/backends/systemd-creds.js');
+        if (!isSystemdCredsAvailable()) {
+          throw new Error('systemd-creds backend requires systemd >= 256 with --user support');
+        }
+      }
+
       store = createCredentialStore({
         backend: config.credentials.backend,
         encryptionPassword: config.credentials.encryptionPassword,

--- a/packages/proxy/src/core/credentials/backends/systemd-creds.ts
+++ b/packages/proxy/src/core/credentials/backends/systemd-creds.ts
@@ -1,0 +1,255 @@
+/**
+ * systemd-creds credential backend for aquaman
+ *
+ * Stores credentials encrypted with systemd-creds using the user's credential
+ * key (and TPM2 when available). Each credential is a separate .cred file.
+ *
+ * Requirements:
+ *   - systemd >= 256 (for --user support)
+ *   - Linux only
+ *
+ * No root/sudo required — uses `systemd-creds --user` which operates with
+ * the per-user credential key stored by systemd-homed or generated on first use.
+ */
+
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { CredentialStore } from '../store.js';
+
+export interface SystemdCredsStoreOptions {
+  /** Directory to store .cred files. Defaults to ~/.aquaman/creds.d/ */
+  credsDir?: string;
+}
+
+/**
+ * Promise wrapper for execFile that properly handles stdin input.
+ * Node's promisify(execFile) doesn't reliably pipe stdin.
+ */
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { input?: string; encoding?: BufferEncoding; maxBuffer?: number } = {}
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const { input, ...rest } = opts;
+    const proc = execFile(cmd, args, rest as any, (err, stdout, stderr) => {
+      if (err) {
+        (err as any).stderr = stderr;
+        reject(err);
+      } else {
+        resolve({ stdout: stdout as string, stderr: stderr as string });
+      }
+    });
+    if (input != null) {
+      proc.stdin!.write(input);
+      proc.stdin!.end();
+    }
+  });
+}
+
+export class SystemdCredsStore implements CredentialStore {
+  private credsDir: string;
+  private cache = new Map<string, string>();
+  private indexLoaded = false;
+  private index: Array<{ service: string; key: string }> = [];
+
+  constructor(options: SystemdCredsStoreOptions = {}) {
+    this.credsDir =
+      options.credsDir ||
+      path.join(os.homedir(), '.aquaman', 'creds.d');
+
+    if (!fs.existsSync(this.credsDir)) {
+      fs.mkdirSync(this.credsDir, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  /**
+   * Build a filename-safe credential name from service + key.
+   * Uses double-dash separator since service/key names may use single dashes.
+   */
+  private credName(service: string, key: string): string {
+    return `${service}--${key}`;
+  }
+
+  private credPath(service: string, key: string): string {
+    return path.join(this.credsDir, `${this.credName(service, key)}.cred`);
+  }
+
+  private indexPath(): string {
+    return path.join(this.credsDir, '_index.cred');
+  }
+
+  /**
+   * Encrypt a value and write to a .cred file.
+   * Uses `systemd-creds --user encrypt` — no root required.
+   */
+  private async encrypt(name: string, value: string, outPath: string): Promise<void> {
+    const { stdout } = await execFileAsync(
+      'systemd-creds',
+      ['--user', 'encrypt', `--name=${name}`, '-', '-'],
+      { input: value, encoding: 'utf-8', maxBuffer: 1024 * 1024 }
+    );
+    fs.writeFileSync(outPath, stdout, { mode: 0o600 });
+  }
+
+  /**
+   * Decrypt a .cred file and return plaintext.
+   * Uses `systemd-creds --user decrypt` — no root required.
+   */
+  private async decrypt(name: string, inPath: string): Promise<string | null> {
+    if (!fs.existsSync(inPath)) return null;
+    const { stdout } = await execFileAsync(
+      'systemd-creds',
+      ['--user', 'decrypt', `--name=${name}`, inPath, '-'],
+      { encoding: 'utf-8', maxBuffer: 1024 * 1024 }
+    );
+    // systemd-creds may append a trailing newline
+    return stdout.replace(/\n$/, '');
+  }
+
+  /**
+   * Load the encrypted index of all stored credentials.
+   */
+  private async loadIndex(): Promise<Array<{ service: string; key: string }>> {
+    if (this.indexLoaded) return this.index;
+    try {
+      const raw = await this.decrypt('_index', this.indexPath());
+      if (raw) {
+        this.index = JSON.parse(raw);
+      }
+    } catch {
+      // No index yet or decrypt failed — start fresh
+      this.index = [];
+    }
+    this.indexLoaded = true;
+    return this.index;
+  }
+
+  /**
+   * Save the credential index (also encrypted).
+   */
+  private async saveIndex(): Promise<void> {
+    await this.encrypt('_index', JSON.stringify(this.index), this.indexPath());
+  }
+
+  async get(service: string, key: string): Promise<string | null> {
+    const cacheKey = this.credName(service, key);
+
+    // Check in-memory cache first
+    if (this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey)!;
+    }
+
+    const credFile = this.credPath(service, key);
+    if (!fs.existsSync(credFile)) return null;
+
+    try {
+      const value = await this.decrypt(cacheKey, credFile);
+      if (value !== null) {
+        this.cache.set(cacheKey, value);
+      }
+      return value;
+    } catch (err) {
+      throw new Error(
+        `Failed to decrypt credential ${service}/${key}: ${(err as Error).message}`
+      );
+    }
+  }
+
+  async set(
+    service: string,
+    key: string,
+    value: string,
+    _metadata?: Record<string, string>
+  ): Promise<void> {
+    const cacheKey = this.credName(service, key);
+    const credFile = this.credPath(service, key);
+
+    try {
+      await this.encrypt(cacheKey, value, credFile);
+    } catch (err) {
+      throw new Error(
+        `Failed to encrypt credential ${service}/${key}: ${(err as Error).message}`
+      );
+    }
+
+    // Update in-memory cache
+    this.cache.set(cacheKey, value);
+
+    // Update index
+    const index = await this.loadIndex();
+    const exists = index.some(
+      (e) => e.service === service && e.key === key
+    );
+    if (!exists) {
+      index.push({ service, key });
+      await this.saveIndex();
+    }
+  }
+
+  async delete(service: string, key: string): Promise<boolean> {
+    const cacheKey = this.credName(service, key);
+    const credFile = this.credPath(service, key);
+
+    if (!fs.existsSync(credFile)) return false;
+
+    fs.unlinkSync(credFile);
+    this.cache.delete(cacheKey);
+
+    // Update index
+    const index = await this.loadIndex();
+    const before = index.length;
+    this.index = index.filter(
+      (e) => !(e.service === service && e.key === key)
+    );
+    if (this.index.length !== before) {
+      await this.saveIndex();
+    }
+
+    return true;
+  }
+
+  async list(
+    service?: string
+  ): Promise<Array<{ service: string; key: string }>> {
+    const index = await this.loadIndex();
+    if (service) {
+      return index.filter((e) => e.service === service);
+    }
+    return [...index];
+  }
+
+  async exists(service: string, key: string): Promise<boolean> {
+    const credFile = this.credPath(service, key);
+    return fs.existsSync(credFile);
+  }
+}
+
+/**
+ * Check if systemd-creds --user is available on this system.
+ * Returns true if systemd >= 256 and the encrypt subcommand works.
+ */
+export async function isSystemdCredsAvailable(): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      'systemd-creds',
+      ['--version'],
+      { encoding: 'utf-8' }
+    );
+    // Parse version: "systemd 258 (...)"
+    const match = stdout.match(/systemd\s+(\d+)/);
+    if (!match) return false;
+    const version = parseInt(match[1], 10);
+    return version >= 256;
+  } catch {
+    return false;
+  }
+}
+
+export function createSystemdCredsStore(
+  options?: SystemdCredsStoreOptions
+): SystemdCredsStore {
+  return new SystemdCredsStore(options);
+}

--- a/packages/proxy/src/core/credentials/backends/systemd-creds.ts
+++ b/packages/proxy/src/core/credentials/backends/systemd-creds.ts
@@ -39,7 +39,9 @@ function execFileAsync(
         (err as any).stderr = stderr;
         reject(err);
       } else {
-        resolve({ stdout: stdout as string, stderr: stderr as string });
+        const out = typeof stdout === 'string' ? stdout : stdout.toString('utf-8');
+        const errOut = typeof stderr === 'string' ? stderr : stderr.toString('utf-8');
+        resolve({ stdout: out, stderr: errOut });
       }
     });
     if (input != null) {

--- a/packages/proxy/src/core/credentials/index.ts
+++ b/packages/proxy/src/core/credentials/index.ts
@@ -30,3 +30,10 @@ export {
   KeePassXCStore,
   createKeePassXCStore
 } from './backends/keepassxc.js';
+
+export {
+  type SystemdCredsStoreOptions,
+  SystemdCredsStore,
+  createSystemdCredsStore,
+  isSystemdCredsAvailable
+} from './backends/systemd-creds.js';

--- a/packages/proxy/src/core/credentials/store.ts
+++ b/packages/proxy/src/core/credentials/store.ts
@@ -10,6 +10,7 @@ import { encryptWithPassword, decryptWithPassword } from '../utils/hash.js';
 import { getConfigDir } from '../utils/config.js';
 import type { CredentialBackend } from '../types.js';
 import { KeePassXCStore } from './backends/keepassxc.js';
+import { SystemdCredsStore } from './backends/systemd-creds.js';
 
 export interface Credential {
   service: string;
@@ -43,6 +44,8 @@ export interface CredentialStoreOptions {
   // KeePassXC options
   keepassxcDatabasePath?: string;
   keepassxcKeyFilePath?: string;
+  // systemd-creds options
+  systemdCredsDir?: string;
 }
 
 /**
@@ -369,6 +372,12 @@ export function createCredentialStore(options: CredentialStoreOptions): Credenti
         throw new Error('KeePassXC backend requires a master password (AQUAMAN_KEEPASS_PASSWORD) or key file (keepassxcKeyFilePath)');
       }
       return new KeePassXCStore({ dbPath, password, keyFilePath: keyFile });
+    }
+
+    case 'systemd-creds': {
+      return new SystemdCredsStore({
+        credsDir: options.systemdCredsDir,
+      });
     }
 
     default:

--- a/packages/proxy/src/core/index.ts
+++ b/packages/proxy/src/core/index.ts
@@ -29,7 +29,11 @@ export {
   createVaultStore,
   type KeePassXCStoreOptions,
   KeePassXCStore,
-  createKeePassXCStore
+  createKeePassXCStore,
+  type SystemdCredsStoreOptions,
+  SystemdCredsStore,
+  createSystemdCredsStore,
+  isSystemdCredsAvailable
 } from './credentials/index.js';
 
 // Audit

--- a/packages/proxy/src/core/types.ts
+++ b/packages/proxy/src/core/types.ts
@@ -53,7 +53,7 @@ export interface ServiceConfig {
 }
 
 export interface CredentialsConfig {
-  backend: 'keychain' | '1password' | 'vault' | 'encrypted-file' | 'keepassxc';
+  backend: 'keychain' | '1password' | 'vault' | 'encrypted-file' | 'keepassxc' | 'systemd-creds';
   proxiedServices: string[];
   encryptionPassword?: string;
   // 1Password options
@@ -67,6 +67,8 @@ export interface CredentialsConfig {
   // KeePassXC options
   keepassxcDatabasePath?: string;
   keepassxcKeyFilePath?: string;
+  // systemd-creds options
+  systemdCredsDir?: string;
 }
 
 export interface AuditConfig {

--- a/packages/proxy/src/core/types.ts
+++ b/packages/proxy/src/core/types.ts
@@ -91,4 +91,4 @@ export interface WrapperConfig {
   openclaw: OpenClawConfig;
 }
 
-export type CredentialBackend = 'keychain' | '1password' | 'vault' | 'encrypted-file' | 'keepassxc';
+export type CredentialBackend = 'keychain' | '1password' | 'vault' | 'encrypted-file' | 'keepassxc' | 'systemd-creds';

--- a/test/e2e/plugin-config-schema.test.ts
+++ b/test/e2e/plugin-config-schema.test.ts
@@ -105,7 +105,7 @@ describe('Plugin Config Schema', () => {
 
   it('should have correct enum values for backend', () => {
     const backendSchema = manifest.configSchema.properties.backend;
-    expect(backendSchema.enum).toEqual(['keychain', '1password', 'vault', 'encrypted-file', 'keepassxc']);
+    expect(backendSchema.enum).toEqual(['keychain', '1password', 'vault', 'encrypted-file', 'keepassxc', 'systemd-creds']);
     expect(backendSchema.default).toBe('keychain');
   });
 

--- a/test/unit/credentials/backends/systemd-creds.test.ts
+++ b/test/unit/credentials/backends/systemd-creds.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for systemd-creds credential backend
+ *
+ * These tests require systemd >= 256 with --user support.
+ * They will be skipped on systems without systemd-creds.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SystemdCredsStore, isSystemdCredsAvailable } from 'aquaman-core';
+
+import { execFileSync } from 'node:child_process';
+
+// Synchronous check at module load time so skipIf() works
+let available = false;
+try {
+  const out = execFileSync('systemd-creds', ['--version'], { encoding: 'utf-8' });
+  const match = out.match(/systemd\s+(\d+)/);
+  available = match ? parseInt(match[1], 10) >= 256 : false;
+} catch {
+  available = false;
+}
+
+describe('SystemdCredsStore', () => {
+  let store: SystemdCredsStore;
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = path.join(
+      os.tmpdir(),
+      `aquaman-systemd-creds-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    fs.mkdirSync(testDir, { recursive: true });
+    store = new SystemdCredsStore({ credsDir: testDir });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true });
+    }
+  });
+
+  describe('constructor', () => {
+    it('should create the creds directory if it does not exist', () => {
+      const newDir = path.join(testDir, 'nested', 'creds');
+      new SystemdCredsStore({ credsDir: newDir });
+      expect(fs.existsSync(newDir)).toBe(true);
+    });
+  });
+
+  describe('set and get', () => {
+    it.skipIf(!available)(
+      'should store and retrieve a credential',
+      async () => {
+        await store.set('anthropic', 'api_key', 'sk-ant-12345');
+        const value = await store.get('anthropic', 'api_key');
+        expect(value).toBe('sk-ant-12345');
+      }
+    );
+
+    it.skipIf(!available)(
+      'should return null for non-existent credential',
+      async () => {
+        const value = await store.get('nonexistent', 'key');
+        expect(value).toBeNull();
+      }
+    );
+
+    it.skipIf(!available)(
+      'should overwrite existing credential',
+      async () => {
+        await store.set('openai', 'api_key', 'sk-old');
+        await store.set('openai', 'api_key', 'sk-new');
+        const value = await store.get('openai', 'api_key');
+        expect(value).toBe('sk-new');
+      }
+    );
+
+    it.skipIf(!available)(
+      'should handle special characters in values',
+      async () => {
+        const specialValue = 'p@$$w0rd!#%&*(){}[]|\\:";\'<>?,./~`';
+        await store.set('test', 'special', specialValue);
+        const value = await store.get('test', 'special');
+        expect(value).toBe(specialValue);
+      }
+    );
+
+    it.skipIf(!available)(
+      'should use in-memory cache on second read',
+      async () => {
+        await store.set('cached', 'key', 'value');
+
+        // First read populates cache
+        const v1 = await store.get('cached', 'key');
+        expect(v1).toBe('value');
+
+        // Delete the file — cached read should still work
+        const credFile = path.join(testDir, 'cached--key.cred');
+        fs.unlinkSync(credFile);
+
+        const v2 = await store.get('cached', 'key');
+        expect(v2).toBe('value');
+      }
+    );
+  });
+
+  describe('delete', () => {
+    it.skipIf(!available)(
+      'should delete a credential and return true',
+      async () => {
+        await store.set('deleteme', 'api_key', 'gone');
+        const deleted = await store.delete('deleteme', 'api_key');
+        expect(deleted).toBe(true);
+
+        const value = await store.get('deleteme', 'api_key');
+        expect(value).toBeNull();
+      }
+    );
+
+    it('should return false for non-existent credential', async () => {
+      const deleted = await store.delete('nonexistent', 'key');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('list', () => {
+    it.skipIf(!available)(
+      'should list all stored credentials',
+      async () => {
+        await store.set('svc-a', 'key1', 'val1');
+        await store.set('svc-b', 'key2', 'val2');
+
+        const all = await store.list();
+        expect(all).toHaveLength(2);
+        expect(all).toContainEqual({ service: 'svc-a', key: 'key1' });
+        expect(all).toContainEqual({ service: 'svc-b', key: 'key2' });
+      }
+    );
+
+    it.skipIf(!available)(
+      'should filter by service',
+      async () => {
+        await store.set('alpha', 'key1', 'val1');
+        await store.set('beta', 'key2', 'val2');
+
+        const filtered = await store.list('alpha');
+        expect(filtered).toHaveLength(1);
+        expect(filtered[0]).toEqual({ service: 'alpha', key: 'key1' });
+      }
+    );
+  });
+
+  describe('exists', () => {
+    it.skipIf(!available)(
+      'should return true for existing credential',
+      async () => {
+        await store.set('exists-test', 'key', 'val');
+        expect(await store.exists('exists-test', 'key')).toBe(true);
+      }
+    );
+
+    it('should return false for non-existent credential', async () => {
+      expect(await store.exists('nope', 'key')).toBe(false);
+    });
+  });
+});
+
+describe('isSystemdCredsAvailable', () => {
+  it('should return a boolean', async () => {
+    const result = await isSystemdCredsAvailable();
+    expect(typeof result).toBe('boolean');
+  });
+});


### PR DESCRIPTION
Add a new credential backend using systemd-creds --user (systemd >= 256) for hardware-backed credential encryption via TPM2.

Key features:
- No root/sudo required — uses systemd-creds --user
- TPM2 binding — credentials can't be decrypted on another machine
- No master password — key managed by systemd per-user
- Each credential stored as a separate .cred file
- In-memory caching to minimize decrypt overhead
- Encrypted index file for credential enumeration

Files changed:
- New: backends/systemd-creds.ts — full CredentialStore implementation
- New: systemd-creds.test.ts — unit tests (skipped on non-systemd systems)
- New: docs/systemd-creds-backend.md — usage and troubleshooting guide
- Modified: types.ts, store.ts, index.ts — add systemd-creds to backend enum/factory
- Modified: CLI, plugin schema, README, CLAUDE.md — documentation updates