### PR TITLE
v0.9.1 — OpenClaw 2026.3.8 + Mistral & Hugging Face

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,10 @@ jobs:
           path: |
             /usr/local/lib/node_modules/openclaw
             /usr/local/bin/openclaw
-          key: openclaw-${{ runner.os }}-node24-2026.2.15
+          key: openclaw-${{ runner.os }}-node24-2026.3.8
       - name: Install openclaw
         if: steps.cache-openclaw.outputs.cache-hit != 'true'
-        run: npm install -g openclaw@2026.2.15
+        run: npm install -g openclaw@2026.3.8
       - run: npx vitest run test/e2e/openclaw-plugin.test.ts
 
       - name: Install plugin for security audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ OpenClaw 2026.2.15+ also reports an environment-level advisory:
 
 There is no suppression mechanism for code findings (no inline annotations, no `.auditignore`). The only fix is to ensure trigger patterns don't co-exist in the same file.
 
-**Current state (v0.7.0, tested through 2026.2.15):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9).
+**Current state (v0.9.1, tested through 2026.3.8):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9). Note: OpenClaw 2026.3.x fresh installs default `tools.profile` to `messaging` — `aquaman_status` tool may not surface unless the operator configures `tools.profile` to include it.
 
 **Mitigations:**
 - `aquaman setup` auto-sets `plugins.allow: ["aquaman-plugin"]` in `openclaw.json` (resolves the `extensions_no_allowlist` audit finding)
@@ -158,7 +158,9 @@ this.keytar = mod.default || mod;
 2. `globalThis.fetch` interceptor matches hostname → service name
 3. Rewrites URL to `http://aquaman.local/telegram/sendMessage` (dispatched over UDS)
 4. Proxy handles auth based on `authMode`:
-   - `header`: injects auth header (Anthropic, OpenAI, GitHub, xAI, Cloudflare AI Gateway, Slack, Discord, Matrix, Mattermost, LINE, Twitch, ElevenLabs, Telnyx, Zalo)
+   - `header`: injects auth header
+     - **Providers:** Anthropic, OpenAI, GitHub, xAI, Cloudflare AI Gateway, Mistral, Hugging Face, ElevenLabs
+     - **Channels:** Slack, Discord, Matrix, Mattermost, LINE, Twitch, Telnyx, Zalo
    - `url-path`: rewrites path to `/bot<TOKEN>/method` (Telegram)
    - `basic`: injects `Authorization: Basic base64(user:pass)` (Twilio, BlueBubbles, Nextcloud Talk)
    - `oauth`: exchanges client credentials for access token (MS Teams, Feishu, Google Chat)
@@ -409,9 +411,9 @@ curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/messag
 npx tsx packages/proxy/src/cli/index.ts stop
 ```
 
-## Manual Channel Testing
+## Manual Testing
 
-Step-by-step guide for manually testing credential injection across all auth modes.
+Step-by-step guide for manually testing credential injection across all auth modes (providers and channels).
 
 ### 1. Store test credentials
 
@@ -421,13 +423,16 @@ node -e "
 const kt = require('./node_modules/keytar');
 const k = kt.default || kt;
 Promise.all([
-  // Header auth
+  // Providers (header auth)
   k.setPassword('aquaman/anthropic', 'api_key', 'sk-ant-manual-test'),
+  k.setPassword('aquaman/mistral', 'api_key', 'mistral-manual-test-key'),
+  k.setPassword('aquaman/huggingface', 'api_key', 'hf-manual-test-key'),
+  // Channels (header auth)
   k.setPassword('aquaman/slack', 'bot_token', 'xoxb-manual-test-token'),
   k.setPassword('aquaman/discord', 'bot_token', 'discord-manual-test-token'),
-  // URL-path auth
+  // Channels (URL-path auth)
   k.setPassword('aquaman/telegram', 'bot_token', '123456:MANUAL-TEST-TOKEN'),
-  // Basic auth
+  // Channels (basic auth)
   k.setPassword('aquaman/twilio', 'account_sid', 'AC-manual-test-sid'),
   k.setPassword('aquaman/twilio', 'auth_token', 'manual-test-auth-token'),
 ]).then(() => console.log('All test credentials stored'));
@@ -443,7 +448,9 @@ npx tsx packages/proxy/src/cli/index.ts plugin-mode
 
 ### 3. Test each auth mode
 
-**Header auth (Anthropic):**
+#### Providers
+
+**Anthropic (header auth):**
 ```bash
 curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/messages \
   -H "Content-Type: application/json" \
@@ -451,25 +458,43 @@ curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/messag
 # Expect: 401 from Anthropic (confirms proxy injected the test key)
 ```
 
-**Header auth (Slack):**
+**Mistral (header auth):**
+```bash
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/mistral/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"mistral-large-latest","messages":[{"role":"user","content":"hi"}]}'
+# Expect: 401 from Mistral (confirms Bearer token injected)
+```
+
+**Hugging Face (header auth):**
+```bash
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/huggingface/models/meta-llama/Llama-3-8B \
+  -H "Content-Type: application/json" \
+  -d '{"inputs":"hi"}'
+# Expect: 401 from Hugging Face (confirms Bearer token injected)
+```
+
+#### Channels
+
+**Slack (header auth):**
 ```bash
 curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/slack/auth.test
 # Expect: {"ok":false,"error":"invalid_auth"} (confirms Bearer token injected)
 ```
 
-**Header auth (Discord):**
+**Discord (header auth):**
 ```bash
 curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/discord/api/v10/users/@me
 # Expect: 401 from Discord (confirms Bot token injected)
 ```
 
-**URL-path auth (Telegram):**
+**Telegram (URL-path auth):**
 ```bash
 curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/telegram/getMe
 # Expect: {"ok":false,"error_code":401} (token injected into URL path)
 ```
 
-**Basic auth (Twilio):**
+**Twilio (basic auth):**
 ```bash
 curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/twilio/2010-04-01/Accounts.json
 # Expect: 401 from Twilio (Basic auth header injected)
@@ -499,7 +524,11 @@ node -e "
 const kt = require('./node_modules/keytar');
 const k = kt.default || kt;
 Promise.all([
+  // Providers
   k.deletePassword('aquaman/anthropic', 'api_key'),
+  k.deletePassword('aquaman/mistral', 'api_key'),
+  k.deletePassword('aquaman/huggingface', 'api_key'),
+  // Channels
   k.deletePassword('aquaman/slack', 'bot_token'),
   k.deletePassword('aquaman/discord', 'bot_token'),
   k.deletePassword('aquaman/telegram', 'bot_token'),
@@ -525,7 +554,7 @@ Promise.all([
 | `packages/proxy/src/core/audit/logger.ts` | Hash-chained logging |
 | `packages/proxy/src/daemon.ts` | HTTP proxy server on UDS (header, url-path, basic, oauth auth modes) |
 | `packages/proxy/src/cli/index.ts` | CLI (Commander.js, 18 commands incl. `setup`, `doctor`, `migrate openclaw`) |
-| `packages/proxy/src/service-registry.ts` | Builtin service definitions (23 services) |
+| `packages/proxy/src/service-registry.ts` | Builtin service definitions (25 services) |
 | `packages/proxy/src/oauth-token-cache.ts` | OAuth client credentials token exchange + caching |
 | `packages/proxy/src/migration/openclaw-migrator.ts` | Migrates channel + plugin creds from openclaw.json to secure store |
 | `packages/proxy/src/openclaw/env-writer.ts` | Generates env vars for OpenClaw integration |
@@ -538,7 +567,8 @@ Promise.all([
 | `packages/plugin/src/http-interceptor.ts` | `globalThis.fetch` override for channel traffic interception (uses `undici.Agent` with UDS dispatcher) |
 | `test/e2e/openclaw-plugin.test.ts` | Plugin integration tests |
 | `test/e2e/credential-proxy.test.ts` | Proxy E2E tests |
-| `test/e2e/channel-credential-injection.test.ts` | Channel auth mode E2E tests (Telegram, Twilio, Twitch, etc.) |
+| `test/e2e/channel-credential-injection.test.ts` | Channel auth mode E2E tests (Telegram, Twilio, Twitch, Slack, etc.) |
+| `test/e2e/provider-credential-injection.test.ts` | LLM/AI provider auth E2E tests (xAI, Cloudflare AI, Mistral, Hugging Face, ElevenLabs) |
 | `test/e2e/oauth-credential-injection.test.ts` | OAuth flow E2E tests (mock token server) |
 | `test/e2e/keychain-proxy-flow.test.ts` | Real keychain backend E2E (macOS only) |
 | `test/e2e/cli-plugin-mode.test.ts` | CLI startup/output E2E tests |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/openclaw:latest
 
 # Install aquaman proxy (includes credential stores, audit, CLI)
-RUN npm install -g aquaman-proxy@0.9.0
+RUN npm install -g aquaman-proxy@0.9.1
 
 # Install plugin into OpenClaw extensions
 RUN mkdir -p /home/node/.openclaw/extensions/aquaman-plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Credential isolation proxy for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞",
   "type": "module",
@@ -42,7 +42,7 @@
     "@types/ws": "^8.5.10",
     "@vitest/coverage-v8": "^1.2.0",
     "ajv": "^8.17.0",
-    "openclaw": "^2026.2.9",
+    "openclaw": "^2026.3.8",
     "oxlint": "^0.2.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -25,6 +25,7 @@ Agent / OpenClaw Gateway              Aquaman Proxy
                                          │  (hash-chained log)
                                          ▼
                                api.anthropic.com
+                               api.mistral.ai
                                api.telegram.org
                                slack.com/api  ...
 ```

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -67,6 +67,8 @@ const FALLBACK_HOST_MAP = new Map<string, string>([
   ['api.github.com', 'github'],
   ['api.x.ai', 'xai'],
   ['gateway.ai.cloudflare.com', 'cloudflare-ai'],
+  ['api.mistral.ai', 'mistral'],
+  ['api-inference.huggingface.co', 'huggingface'],
   ['slack.com', 'slack'],
   ['*.slack.com', 'slack'],
   ['discord.com', 'discord'],

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Credential isolation plugin for OpenClaw",
   "type": "module",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.0",
-    "aquaman-proxy": "0.9.0"
+    "aquaman-proxy": "0.9.1"
   },
   "peerDependenciesMeta": {
     "aquaman-proxy": {

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -25,11 +25,12 @@ Agent / OpenClaw Gateway              Aquaman Proxy
                                          │  (hash-chained log)
                                          ▼
                                api.anthropic.com
+                               api.mistral.ai
                                api.telegram.org
                                slack.com/api  ...
 ```
 
-This package is the right side. A reverse proxy that listens on a Unix domain socket (`~/.aquaman/proxy.sock`) and injects credentials from secure backends. No TCP port, no network exposure. 23 builtin services, four auth modes.
+This package is the right side. A reverse proxy that listens on a Unix domain socket (`~/.aquaman/proxy.sock`) and injects credentials from secure backends. No TCP port, no network exposure. 25 builtin services, six auth modes.
 
 ## Quick Start
 
@@ -76,15 +77,15 @@ Troubleshooting: `aquaman doctor`
 | `aquaman audit tail` | Recent audit entries |
 | `aquaman audit verify` | Verify hash chain integrity |
 
-## 23 Builtin Services
+## 25 Builtin Services
 
 | Category | Services |
 |----------|----------|
-| **LLM / AI** | Anthropic, OpenAI, GitHub, xAI, Cloudflare AI Gateway |
-| **Header** | Slack, Discord, Matrix, Mattermost, LINE, Twitch, Telnyx, ElevenLabs, Zalo |
-| **URL-path** | Telegram |
-| **HTTP Basic** | Twilio, BlueBubbles, Nextcloud Talk |
-| **OAuth** | MS Teams, Feishu, Google Chat |
+| **Providers** | Anthropic, OpenAI, GitHub, xAI, Cloudflare AI Gateway, Mistral, Hugging Face, ElevenLabs |
+| **Channels (header)** | Slack, Discord, Matrix, Mattermost, LINE, Twitch, Telnyx, Zalo |
+| **Channels (URL-path)** | Telegram |
+| **Channels (basic)** | Twilio, BlueBubbles, Nextcloud Talk |
+| **Channels (OAuth)** | MS Teams, Feishu, Google Chat |
 | **At-rest only** | Nostr, Tlon |
 
 ## Documentation

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-proxy",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Credential isolation proxy daemon for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -1543,7 +1543,7 @@ credentials
 credentials
   .command('guide')
   .description('Show setup commands for seeding credentials based on your backend')
-  .option('--backend <backend>', 'Override backend (keychain, encrypted-file, vault, 1password, bitwarden)')
+  .option('--backend <backend>', 'Override backend (keychain, encrypted-file, keepassxc, 1password, vault, systemd-creds, bitwarden)')
   .option('--service <name>', 'Show commands for a single service only')
   .action(async (options) => {
     const config = loadConfig();

--- a/packages/proxy/src/service-registry.ts
+++ b/packages/proxy/src/service-registry.ts
@@ -99,6 +99,26 @@ const BUILTIN_SERVICES: ServiceDefinition[] = [
     authMode: 'header',
     hostPatterns: ['gateway.ai.cloudflare.com']
   },
+  {
+    name: 'mistral',
+    upstream: 'https://api.mistral.ai',
+    authHeader: 'Authorization',
+    authPrefix: 'Bearer ',
+    credentialKey: 'api_key',
+    description: 'Mistral AI API',
+    authMode: 'header',
+    hostPatterns: ['api.mistral.ai']
+  },
+  {
+    name: 'huggingface',
+    upstream: 'https://api-inference.huggingface.co',
+    authHeader: 'Authorization',
+    authPrefix: 'Bearer ',
+    credentialKey: 'api_key',
+    description: 'Hugging Face Inference API',
+    authMode: 'header',
+    hostPatterns: ['api-inference.huggingface.co']
+  },
 
   // ── Header Auth Channels ────────────────────────────────────────────
   {

--- a/test/e2e/channel-credential-injection.test.ts
+++ b/test/e2e/channel-credential-injection.test.ts
@@ -1,10 +1,15 @@
 /**
- * E2E tests for channel credential injection (new auth modes).
+ * E2E tests for channel credential injection.
  *
- * Tests the new auth modes added to support OpenClaw channel credentials:
+ * Tests auth injection for OpenClaw messaging channel services:
+ * - Header auth (Slack, Discord, Matrix, LINE, Zalo)
  * - URL-path auth (Telegram: /bot<TOKEN>/method)
  * - HTTP Basic auth (Twilio: base64(sid:token))
  * - Additional headers (Twitch: Authorization + Client-Id)
+ * - Auth mode "none" (Nostr: at-rest storage only, proxy rejects traffic)
+ *
+ * LLM/AI provider tests are in provider-credential-injection.test.ts.
+ * OAuth channel tests (MS Teams, Feishu, Google Chat) are in oauth-credential-injection.test.ts.
  *
  * Architecture:
  *   Test -> Proxy (UDS) -> Mock Upstream (dynamic port)
@@ -33,14 +38,12 @@ describe('Channel Credential Injection E2E', () => {
   const TEST_TWILIO_TOKEN = 'auth-token-test-789';
   const TEST_TWITCH_TOKEN = 'twitch-oauth-token-abc';
   const TEST_TWITCH_CLIENT_ID = 'twitch-client-id-xyz';
-  const TEST_ELEVENLABS_KEY = 'el-api-key-test-456';
   const TEST_SLACK_TOKEN = 'xoxb-slack-bot-token-test';
   const TEST_DISCORD_TOKEN = 'discord-bot-token-test-123';
   const TEST_MATRIX_TOKEN = 'syt_matrix_access_token_test';
   const TEST_LINE_TOKEN = 'line-channel-access-token-test';
   const TEST_ZALO_TOKEN = 'zalo-bot-token-test-456';
-  const TEST_XAI_KEY = 'xai-api-key-test-789';
-  const TEST_CLOUDFLARE_AI_TOKEN = 'cf-ai-api-token-test-012';
+  const TEST_TELNYX_KEY = 'telnyx-api-key-test-321';
 
   beforeEach(async () => {
     upstream = createMockUpstream();
@@ -53,14 +56,12 @@ describe('Channel Credential Injection E2E', () => {
     await store.set('twilio', 'auth_token', TEST_TWILIO_TOKEN);
     await store.set('twitch', 'access_token', TEST_TWITCH_TOKEN);
     await store.set('twitch', 'client_id', TEST_TWITCH_CLIENT_ID);
-    await store.set('elevenlabs', 'api_key', TEST_ELEVENLABS_KEY);
     await store.set('slack', 'bot_token', TEST_SLACK_TOKEN);
     await store.set('discord', 'bot_token', TEST_DISCORD_TOKEN);
     await store.set('matrix', 'access_token', TEST_MATRIX_TOKEN);
     await store.set('line', 'channel_access_token', TEST_LINE_TOKEN);
     await store.set('zalo', 'bot_token', TEST_ZALO_TOKEN);
-    await store.set('xai', 'api_key', TEST_XAI_KEY);
-    await store.set('cloudflare-ai', 'api_token', TEST_CLOUDFLARE_AI_TOKEN);
+    await store.set('telnyx', 'api_key', TEST_TELNYX_KEY);
 
     requestLog = [];
     socketPath = tmpSocketPath();
@@ -75,9 +76,6 @@ describe('Channel Credential Injection E2E', () => {
       upstream: `http://127.0.0.1:${upstreamPort}`
     });
     registry.override('twitch', {
-      upstream: `http://127.0.0.1:${upstreamPort}`
-    });
-    registry.override('elevenlabs', {
       upstream: `http://127.0.0.1:${upstreamPort}`
     });
     registry.override('slack', {
@@ -95,10 +93,7 @@ describe('Channel Credential Injection E2E', () => {
     registry.override('zalo', {
       upstream: `http://127.0.0.1:${upstreamPort}`
     });
-    registry.override('xai', {
-      upstream: `http://127.0.0.1:${upstreamPort}`
-    });
-    registry.override('cloudflare-ai', {
+    registry.override('telnyx', {
       upstream: `http://127.0.0.1:${upstreamPort}`
     });
 
@@ -106,7 +101,7 @@ describe('Channel Credential Injection E2E', () => {
       socketPath,
       store,
       serviceRegistry: registry,
-      allowedServices: ['telegram', 'twilio', 'twitch', 'elevenlabs', 'slack', 'discord', 'matrix', 'line', 'zalo', 'xai', 'cloudflare-ai'],
+      allowedServices: ['telegram', 'twilio', 'twitch', 'slack', 'discord', 'matrix', 'line', 'zalo', 'telnyx'],
       onRequest: (info) => {
         requestLog.push(info);
       }
@@ -205,22 +200,6 @@ describe('Channel Credential Injection E2E', () => {
     });
   });
 
-  describe('ElevenLabs custom header auth', () => {
-    it('injects xi-api-key header', async () => {
-      const response = await udsFetch(socketPath, '/elevenlabs/v1/text-to-speech/voice-id', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: 'Hello', model_id: 'eleven_monolingual_v1' })
-      });
-
-      expect(response.status).toBe(200);
-
-      const lastRequest = upstream.getLastRequest();
-      expect(lastRequest).toBeDefined();
-      expect(lastRequest!.headers['xi-api-key']).toBe(TEST_ELEVENLABS_KEY);
-    });
-  });
-
   describe('Slack header auth', () => {
     it('injects Bearer token for Slack requests', async () => {
       const response = await udsFetch(socketPath, '/slack/chat.postMessage', {
@@ -303,37 +282,19 @@ describe('Channel Credential Injection E2E', () => {
     });
   });
 
-  describe('xAI header auth', () => {
-    it('injects Bearer token for xAI Grok requests', async () => {
-      const response = await udsFetch(socketPath, '/xai/v1/chat/completions', {
+  describe('Telnyx header auth', () => {
+    it('injects Bearer token for Telnyx requests', async () => {
+      const response = await udsFetch(socketPath, '/telnyx/v2/messages', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: 'grok-3', messages: [{ role: 'user', content: 'hi' }] })
+        body: JSON.stringify({ from: '+15551234567', to: '+15559876543', text: 'hello' })
       });
 
       expect(response.status).toBe(200);
 
       const lastRequest = upstream.getLastRequest();
       expect(lastRequest).toBeDefined();
-      expect(lastRequest!.headers['authorization']).toBe(`Bearer ${TEST_XAI_KEY}`);
-      expect(lastRequest!.path).toBe('/v1/chat/completions');
-    });
-  });
-
-  describe('Cloudflare AI Gateway header auth', () => {
-    it('injects cf-aig-authorization header for Cloudflare AI Gateway requests', async () => {
-      const response = await udsFetch(socketPath, '/cloudflare-ai/v1/account-id/gateway-id/anthropic/v1/messages', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 5, messages: [{ role: 'user', content: 'hi' }] })
-      });
-
-      expect(response.status).toBe(200);
-
-      const lastRequest = upstream.getLastRequest();
-      expect(lastRequest).toBeDefined();
-      expect(lastRequest!.headers['cf-aig-authorization']).toBe(`Bearer ${TEST_CLOUDFLARE_AI_TOKEN}`);
-      expect(lastRequest!.path).toBe('/v1/account-id/gateway-id/anthropic/v1/messages');
+      expect(lastRequest!.headers['authorization']).toBe(`Bearer ${TEST_TELNYX_KEY}`);
     });
   });
 

--- a/test/e2e/provider-credential-injection.test.ts
+++ b/test/e2e/provider-credential-injection.test.ts
@@ -1,0 +1,172 @@
+/**
+ * E2E tests for LLM/AI provider credential injection.
+ *
+ * Tests header auth injection for AI providers beyond the core three
+ * (Anthropic, OpenAI, GitHub — tested in credential-injection.test.ts).
+ *
+ * Architecture:
+ *   Test -> Proxy (UDS) -> Mock Upstream (dynamic port)
+ *                |
+ *        Credential Store (Memory)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { CredentialProxy, createCredentialProxy, createServiceRegistry } from 'aquaman-proxy';
+import { MemoryStore } from 'aquaman-core';
+import { MockUpstream, createMockUpstream } from '../helpers/mock-upstream.js';
+import type { RequestInfo } from 'aquaman-proxy';
+import { tmpSocketPath, cleanupSocket, udsFetch } from '../helpers/uds-proxy.js';
+
+describe('Provider Credential Injection E2E', () => {
+  let proxy: CredentialProxy;
+  let upstream: MockUpstream;
+  let store: MemoryStore;
+  let requestLog: RequestInfo[];
+  let socketPath: string;
+  let upstreamPort: number;
+
+  // Test credentials
+  const TEST_XAI_KEY = 'xai-api-key-test-789';
+  const TEST_CLOUDFLARE_AI_TOKEN = 'cf-ai-api-token-test-012';
+  const TEST_MISTRAL_KEY = 'mistral-api-key-test-345';
+  const TEST_HUGGINGFACE_KEY = 'hf-api-key-test-678';
+  const TEST_ELEVENLABS_KEY = 'el-api-key-test-456';
+
+  beforeEach(async () => {
+    upstream = createMockUpstream();
+    await upstream.start(0);
+    upstreamPort = upstream.port;
+
+    store = new MemoryStore();
+    await store.set('xai', 'api_key', TEST_XAI_KEY);
+    await store.set('cloudflare-ai', 'api_token', TEST_CLOUDFLARE_AI_TOKEN);
+    await store.set('mistral', 'api_key', TEST_MISTRAL_KEY);
+    await store.set('huggingface', 'api_key', TEST_HUGGINGFACE_KEY);
+    await store.set('elevenlabs', 'api_key', TEST_ELEVENLABS_KEY);
+
+    requestLog = [];
+    socketPath = tmpSocketPath();
+
+    const registry = createServiceRegistry();
+
+    // Override upstreams to point to mock
+    registry.override('xai', {
+      upstream: `http://127.0.0.1:${upstreamPort}`
+    });
+    registry.override('cloudflare-ai', {
+      upstream: `http://127.0.0.1:${upstreamPort}`
+    });
+    registry.override('mistral', {
+      upstream: `http://127.0.0.1:${upstreamPort}`
+    });
+    registry.override('huggingface', {
+      upstream: `http://127.0.0.1:${upstreamPort}`
+    });
+    registry.override('elevenlabs', {
+      upstream: `http://127.0.0.1:${upstreamPort}`
+    });
+
+    proxy = createCredentialProxy({
+      socketPath,
+      store,
+      serviceRegistry: registry,
+      allowedServices: ['xai', 'cloudflare-ai', 'mistral', 'huggingface', 'elevenlabs'],
+      onRequest: (info) => {
+        requestLog.push(info);
+      }
+    });
+
+    await proxy.start();
+  });
+
+  afterEach(async () => {
+    await proxy.stop();
+    await upstream.stop();
+    store.clear();
+    cleanupSocket(socketPath);
+  });
+
+  describe('xAI header auth', () => {
+    it('injects Bearer token for xAI Grok requests', async () => {
+      const response = await udsFetch(socketPath, '/xai/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'grok-3', messages: [{ role: 'user', content: 'hi' }] })
+      });
+
+      expect(response.status).toBe(200);
+
+      const lastRequest = upstream.getLastRequest();
+      expect(lastRequest).toBeDefined();
+      expect(lastRequest!.headers['authorization']).toBe(`Bearer ${TEST_XAI_KEY}`);
+      expect(lastRequest!.path).toBe('/v1/chat/completions');
+    });
+  });
+
+  describe('Cloudflare AI Gateway header auth', () => {
+    it('injects cf-aig-authorization header for Cloudflare AI Gateway requests', async () => {
+      const response = await udsFetch(socketPath, '/cloudflare-ai/v1/account-id/gateway-id/anthropic/v1/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 5, messages: [{ role: 'user', content: 'hi' }] })
+      });
+
+      expect(response.status).toBe(200);
+
+      const lastRequest = upstream.getLastRequest();
+      expect(lastRequest).toBeDefined();
+      expect(lastRequest!.headers['cf-aig-authorization']).toBe(`Bearer ${TEST_CLOUDFLARE_AI_TOKEN}`);
+      expect(lastRequest!.path).toBe('/v1/account-id/gateway-id/anthropic/v1/messages');
+    });
+  });
+
+  describe('Mistral header auth', () => {
+    it('injects Bearer token for Mistral requests', async () => {
+      const response = await udsFetch(socketPath, '/mistral/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'mistral-large-latest', messages: [{ role: 'user', content: 'hi' }] })
+      });
+
+      expect(response.status).toBe(200);
+
+      const lastRequest = upstream.getLastRequest();
+      expect(lastRequest).toBeDefined();
+      expect(lastRequest!.headers['authorization']).toBe(`Bearer ${TEST_MISTRAL_KEY}`);
+      expect(lastRequest!.path).toBe('/v1/chat/completions');
+    });
+  });
+
+  describe('Hugging Face header auth', () => {
+    it('injects Bearer token for Hugging Face Inference requests', async () => {
+      const response = await udsFetch(socketPath, '/huggingface/models/meta-llama/Llama-3-8B/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] })
+      });
+
+      expect(response.status).toBe(200);
+
+      const lastRequest = upstream.getLastRequest();
+      expect(lastRequest).toBeDefined();
+      expect(lastRequest!.headers['authorization']).toBe(`Bearer ${TEST_HUGGINGFACE_KEY}`);
+      expect(lastRequest!.path).toBe('/models/meta-llama/Llama-3-8B/v1/chat/completions');
+    });
+  });
+
+  describe('ElevenLabs custom header auth', () => {
+    it('injects xi-api-key header', async () => {
+      const response = await udsFetch(socketPath, '/elevenlabs/v1/text-to-speech/voice-id', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Hello', model_id: 'eleven_monolingual_v1' })
+      });
+
+      expect(response.status).toBe(200);
+
+      const lastRequest = upstream.getLastRequest();
+      expect(lastRequest).toBeDefined();
+      expect(lastRequest!.headers['xi-api-key']).toBe(TEST_ELEVENLABS_KEY);
+    });
+  });
+});


### PR DESCRIPTION
- **Mistral + Hugging Face** builtin services (25 total, was 23) — Bearer header auth, E2E tested
- **CI → OpenClaw 2026.3.8** — verified across 10 releases, no breaking changes, security audit clean (2 expected findings)
- **Test split** — separated `provider-credential-injection.test.ts` from `channel-credential-injection.test.ts`
- **Docs cleanup** — consistent provider/channel distinction in CLAUDE.md, ROADMAP.md, READMEs
- **Bug fix** — `credentials guide --backend` was missing `keepassxc` and `systemd-creds`
- **Version 0.9.1** across all packages + Docker