### PR TITLE
Release/v0.10.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -666,7 +666,7 @@ Promise.all([
 | `packages/proxy/src/core/audit/logger.ts` | Hash-chained logging |
 | `packages/proxy/src/daemon.ts` | HTTP proxy server on UDS (header, url-path, basic, oauth auth modes) |
 | `packages/proxy/src/request-policy.ts` | Request-level policy enforcement (method+path rules, segment-based glob matching) |
-| `packages/proxy/src/cli/index.ts` | CLI (Commander.js, 18 commands incl. `setup`, `doctor`, `migrate openclaw`) |
+| `packages/proxy/src/cli/index.ts` | CLI (Commander.js, 20 commands incl. `setup`, `doctor`, `policy list/test`, `migrate openclaw`) |
 | `packages/proxy/src/service-registry.ts` | Builtin service definitions (25 services) |
 | `packages/proxy/src/oauth-token-cache.ts` | OAuth client credentials token exchange + caching |
 | `packages/proxy/src/migration/openclaw-migrator.ts` | Migrates channel + plugin creds from openclaw.json to secure store |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ OpenClaw 2026.2.15+ also reports an environment-level advisory:
 
 There is no suppression mechanism for code findings (no inline annotations, no `.auditignore`). The only fix is to ensure trigger patterns don't co-exist in the same file.
 
-**Current state (v0.9.1, tested through 2026.3.8):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9). Note: OpenClaw 2026.3.x fresh installs default `tools.profile` to `messaging` — `aquaman_status` tool may not surface unless the operator configures `tools.profile` to include it.
+**Current state (v0.9.2, tested through 2026.3.8):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The `request-policy.ts` file contains no `child_process`, `process.env`, or `fetch` — zero scanner risk. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9). Note: OpenClaw 2026.3.x fresh installs default `tools.profile` to `messaging` — `aquaman_status` tool may not surface unless the operator configures `tools.profile` to include it.
 
 **Mitigations:**
 - `aquaman setup` auto-sets `plugins.allow: ["aquaman-plugin"]` in `openclaw.json` (resolves the `extensions_no_allowlist` audit finding)
@@ -147,12 +147,13 @@ this.keytar = mod.default || mod;
 **Standard (header auth):**
 1. Agent sends request to `http://aquaman.local/anthropic/v1/messages` (routed to UDS via undici dispatcher)
 2. Proxy parses service name from path (`anthropic`)
-3. Looks up credential from vault: `anthropic/api_key`
-4. Strips any existing auth header from the request
-5. Injects real auth header: `x-api-key: <actual-key-from-vault>`
-6. Forwards to upstream: `https://api.anthropic.com/v1/messages`
-7. Response piped back to agent
-8. Access logged in audit trail with hash chaining
+3. **Policy check:** evaluates method + remaining path against `config.yaml` policy rules (if configured). Denied → 403 JSON, request never gets credentials
+4. Looks up credential from vault: `anthropic/api_key`
+5. Strips any existing auth header from the request
+6. Injects real auth header: `x-api-key: <actual-key-from-vault>`
+7. Forwards to upstream: `https://api.anthropic.com/v1/messages`
+8. Response piped back to agent
+9. Access logged in audit trail with hash chaining
 
 **Channel traffic (via fetch interceptor):**
 1. Channel code calls `fetch('https://api.telegram.org/bot.../sendMessage')`
@@ -392,9 +393,9 @@ openclaw agent --local --message "hello" --session-id test --json 2>&1 | head -8
 ### Automated tests:
 
 ```bash
-npm run test:e2e                # All e2e tests (15 files)
-npm run test:unit               # All unit tests (14 files)
-npm test                        # Everything (~422 tests, 29 files)
+npm run test:e2e                # All e2e tests (17 files)
+npm run test:unit               # All unit tests (18 files)
+npm test                        # Everything (~548 tests, 35 files)
 ```
 
 ### Quick proxy-only smoke test:
@@ -539,6 +540,116 @@ Promise.all([
 "
 ```
 
+## Manual Policy Smoke Test
+
+Step-by-step guide for manually testing request-level policy enforcement.
+
+### 1. Store test credentials
+
+```bash
+node -e "
+const kt = require('./node_modules/keytar');
+const k = kt.default || kt;
+Promise.all([
+  k.setPassword('aquaman/anthropic', 'api_key', 'sk-ant-policy-test'),
+  k.setPassword('aquaman/openai', 'api_key', 'sk-openai-policy-test'),
+  k.setPassword('aquaman/slack', 'bot_token', 'xoxb-policy-test-token'),
+]).then(() => console.log('Test credentials stored'));
+"
+```
+
+### 2. Write policy config
+
+```bash
+cat > ~/.aquaman/config.yaml << 'YAML'
+credentials:
+  backend: keychain
+  proxiedServices: [anthropic, openai, slack]
+audit:
+  enabled: true
+  logDir: ~/.aquaman/audit
+services:
+  configPath: ~/.aquaman/services.yaml
+openclaw:
+  autoLaunch: false
+  configMethod: env
+policy:
+  anthropic:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/v1/organizations/**"
+        action: deny
+  openai:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/v1/organization/**"
+        action: deny
+      - method: DELETE
+        path: "/v1/**"
+        action: deny
+  slack:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/admin.*"
+        action: deny
+YAML
+```
+
+### 3. Start proxy and test
+
+```bash
+npx tsx packages/proxy/src/cli/index.ts daemon &
+sleep 2
+
+# Allowed: Anthropic inference (expect 401 from upstream = credential injected)
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-sonnet-4-20250514","max_tokens":5,"messages":[{"role":"user","content":"hi"}]}'
+# Expect: {"type":"error","error":{"type":"authentication_error",...}}
+
+# Denied: Anthropic admin API (expect 403 from policy)
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/organizations/org123/members
+# Expect: {"error":"Request denied by policy: GET /anthropic/v1/organizations/org123/members","fix":"Check policy rules..."}
+
+# Denied: OpenAI DELETE (expect 403 from policy)
+curl -s -X DELETE --unix-socket ~/.aquaman/proxy.sock http://localhost/openai/v1/files/file-abc
+# Expect: {"error":"Request denied by policy: DELETE /openai/v1/files/file-abc","fix":"..."}
+
+# Denied: Slack admin method (expect 403 from policy)
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/slack/admin.users.list
+# Expect: {"error":"Request denied by policy: GET /slack/admin.users.list","fix":"..."}
+
+# Allowed: Slack normal method (expect response from Slack)
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/slack/auth.test | head -c 100
+# Expect: HTML or JSON from Slack (not 403)
+
+npx tsx packages/proxy/src/cli/index.ts stop
+```
+
+### 4. Verify doctor output
+
+```bash
+npx tsx packages/proxy/src/cli/index.ts doctor
+# Expect: ✓ Policy valid (3 services, 4 rules)
+```
+
+### 5. Cleanup
+
+```bash
+node -e "
+const kt = require('./node_modules/keytar');
+const k = kt.default || kt;
+Promise.all([
+  k.deletePassword('aquaman/anthropic', 'api_key'),
+  k.deletePassword('aquaman/openai', 'api_key'),
+  k.deletePassword('aquaman/slack', 'bot_token'),
+]).then(() => console.log('Test credentials removed'));
+"
+```
+
 ## Key Design Principles
 
 1. **Credentials never in agent memory** - Proxy injects auth, agent sees nothing
@@ -554,6 +665,7 @@ Promise.all([
 | `packages/proxy/src/core/credentials/backends/` | 1Password, Vault, KeePassXC, systemd-creds, and Bitwarden backend implementations |
 | `packages/proxy/src/core/audit/logger.ts` | Hash-chained logging |
 | `packages/proxy/src/daemon.ts` | HTTP proxy server on UDS (header, url-path, basic, oauth auth modes) |
+| `packages/proxy/src/request-policy.ts` | Request-level policy enforcement (method+path rules, segment-based glob matching) |
 | `packages/proxy/src/cli/index.ts` | CLI (Commander.js, 18 commands incl. `setup`, `doctor`, `migrate openclaw`) |
 | `packages/proxy/src/service-registry.ts` | Builtin service definitions (25 services) |
 | `packages/proxy/src/oauth-token-cache.ts` | OAuth client credentials token exchange + caching |
@@ -571,6 +683,8 @@ Promise.all([
 | `test/e2e/channel-credential-injection.test.ts` | Channel auth mode E2E tests (Telegram, Twilio, Twitch, Slack, etc.) |
 | `test/e2e/provider-credential-injection.test.ts` | LLM/AI provider auth E2E tests (xAI, Cloudflare AI, Mistral, Hugging Face, ElevenLabs) |
 | `test/e2e/oauth-credential-injection.test.ts` | OAuth flow E2E tests (mock token server) |
+| `test/e2e/request-policy.test.ts` | Request policy enforcement E2E tests (403 responses, audit logging, backward compat) |
+| `test/unit/request-policy.test.ts` | Request policy unit tests (path matching, policy evaluation, validation, presets) |
 | `test/e2e/keychain-proxy-flow.test.ts` | Real keychain backend E2E (macOS only) |
 | `test/e2e/cli-plugin-mode.test.ts` | CLI startup/output E2E tests |
 | `test/e2e/cli-setup.test.ts` | `aquaman setup` E2E tests |

--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@
 [![codecov](https://codecov.io/gh/tech4242/aquaman/branch/main/graph/badge.svg)](https://codecov.io/gh/tech4242/aquaman)
 [![npm version](https://img.shields.io/npm/v/aquaman-proxy?label=aquaman-proxy)](https://www.npmjs.com/package/aquaman-proxy)
 [![npm downloads](https://img.shields.io/npm/dm/aquaman-proxy)](https://www.npmjs.com/package/aquaman-proxy)
-[![Security: process isolation](https://img.shields.io/badge/security-process%20isolation-critical)](https://github.com/tech4242/aquaman#how-it-works)
+[![Security: process isolation](https://img.shields.io/badge/security-process%20isolation-critical)](https://github.com/tech4242/aquaman#security-model)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Credential isolation for OpenClaw — secrets stay submerged, agents stay dry. Containers protect the host. Aquaman protects the credentials.
+Credential isolation for OpenClaw — secrets stay submerged, agents stay dry.
 
-You have bought yourself a brand new Mac Mini (or credits at your favorite cloud provider) and now you are still scared about your API credentials because you read all the articles. 
+You bought a brand new Mac Mini, set up OpenClaw, and now you're staring at your `~/.openclaw/openclaw.json` wondering why your Anthropic API key is sitting there in plaintext. You read the articles. You know what happens when an agent gets prompt-injected. We get it.
 
-We get it.
+Aquaman fixes this with three layers of defense:
 
-With Aquaman API keys never enter the agent process. Aquaman stores them in a secure vault of your choosing and injects auth headers via a separate proxy. Even a fully compromised agent should not be able to exfiltrate your keys.
+1. **Process isolation** — API keys live in a separate proxy process. The agent never sees them. Even RCE in the agent can't reach credentials — they're in a different address space.
+2. **Request policies** — Per-service rules control *which endpoints* an agent can call. Block admin APIs, prevent deletions, allow drafts but deny sends. Denied requests never get real credentials.
+3. **Tamper-evident audit** — Every credential use is logged with SHA-256 hash chains. You can prove what was accessed and detect tampering after the fact.
+
+No SDK changes required. The proxy is transparent — your agent talks to `aquaman.local`, the proxy injects auth and forwards to the real API.
 
 ## Quick Start
 
@@ -87,43 +91,25 @@ Agent / OpenClaw Gateway              Aquaman Proxy
                                slack.com/api  ...
 ```
 
-1. **Store** — Credentials live in a vault backend (Keychain, 1Password, Vault, Bitwarden, encrypted file)
-2. **Proxy** — Aquaman runs a reverse proxy in a separate process, connected via Unix domain socket — no TCP port, no network exposure
-3. **Inject** — Proxy looks up the credential and adds the auth header before forwarding
+1. **Store** — Credentials live in a vault backend (Keychain, 1Password, Vault, Bitwarden, encrypted file, KeePassXC, systemd-creds)
+2. **Policy** — Proxy checks method + path rules *before* touching credentials. Denied requests get a 403, never real auth headers.
+3. **Inject** — Proxy looks up the credential and adds the auth header before forwarding. 25 builtin services, 4 auth modes (header, URL-path, HTTP Basic, OAuth).
+4. **Audit** — Every credential use is logged with SHA-256 hash chains.
 
 The agent only sees a sentinel hostname (`aquaman.local`). It never sees a key, and no port is open for other processes to probe.
 
-## Credential Backends
+## Security Model
 
-| Backend | Best For | Setup |
-|---------|----------|-------|
-| `keychain` | Local dev on macOS (default) | Works out of the box |
-| `encrypted-file` | Linux, WSL2, CI/CD | AES-256-GCM, password-protected |
-| `keepassxc` | Existing KeePass users | Set `AQUAMAN_KEEPASS_PASSWORD` or key file |
-| `1password` | Team credential sharing | `brew install 1password-cli && op signin` |
-| `vault` | Enterprise secrets management | Set `VAULT_ADDR` + `VAULT_TOKEN` |
-| `systemd-creds` | Linux with systemd ≥ 256 | TPM2-backed, no root required |
-| `bitwarden` | Bitwarden users | `bw login && export BW_SESSION=$(bw unlock --raw)` |
-
-**Important:** `encrypted-file` is a last-resort backend for headless Linux/CI environments without a native keyring. For better security, install `libsecret-1-dev` (for GNOME Keyring), use `systemd-creds` (Linux with TPM2), or use 1Password/Vault.
-
-## Security Audit
-
-`openclaw security audit --deep` reports two expected findings:
-
-- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the proxy as a separate process. This is how aquaman keeps credentials out of the agent.
-- **`tools_reachable_permissive_policy`** — OpenClaw warns that plugin tools (like `aquaman_status`) are reachable when no restrictive tool profile is set. This is an environment-level advisory about your agent's tool policy, not a vulnerability in aquaman. If your agents handle untrusted input, set `"tools": { "profile": "coding" }` in `openclaw.json` to restrict which tools agents can call.
-
-`aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.
+| Layer | What it does | What it stops |
+|-------|-------------|---------------|
+| **Process isolation** | Credentials in separate process, connected via Unix domain socket (`chmod 600`) | Compromised agent can't read keys — different address space, no TCP port to probe |
+| **Service allowlisting** | `proxiedServices` controls which APIs the agent can reach | Agent can't talk to services you didn't authorize |
+| **Request policies** | Method + path rules per service, enforced before credential injection | Agent can reach Anthropic but not its admin API; can draft emails but not send them |
+| **Audit trail** | SHA-256 hash-chained logs of every credential use | Post-incident forensics, tamper detection, compliance evidence |
 
 ## Request Policies
 
-Aquaman has two layers of access control:
-
-1. **Service allowlisting** — `proxiedServices` controls *which services* the agent can reach at all. This is the perimeter.
-2. **Request policies** — per-service method + path rules control *which endpoints* the agent can call. This is the interior.
-
-OAuth scopes can't distinguish between "draft an email" and "send an email" — they're both `gmail.send`. Aquaman's request policies fill that gap: allow the service, then restrict what happens inside it.
+OAuth scopes can't distinguish between "draft an email" and "send an email" — they're both `gmail.send`. Request policies fill that gap: allow the service, then restrict what happens inside it.
 
 ```yaml
 # ~/.aquaman/config.yaml
@@ -157,18 +143,32 @@ policy:
         action: deny          # drafts ok, sending blocked
 ```
 
-**How it works:**
 - **No policy = allow all** (backward compatible)
-- **First match wins** — rules are evaluated top-to-bottom, unmatched requests fall through to `defaultAction`
-- **Denied before auth** — policy is checked before credential injection, so blocked requests never get real auth headers
-- **Path globs:** `*` matches within a segment (like shell glob), `**` matches zero or more path segments
-- **`aquaman setup`** applies safe defaults for stored services (blocks admin/billing endpoints)
+- **First match wins** — rules evaluated top-to-bottom, unmatched requests fall through to `defaultAction`
+- **Denied before auth** — blocked requests never get real credentials
+- **Path globs:** `*` matches within a segment, `**` matches zero or more segments
+- **`aquaman setup`** applies safe defaults (blocks admin/billing endpoints for stored services)
 - **`aquaman doctor`** validates your policy config and warns about typos
 
-## Why Aquaman
+## Credential Backends
 
-**Security** — Process-level credential isolation via Unix domain socket (no TCP port, no network exposure). Socket file permissions (`chmod 600`) restrict access to the owning user. Two-layer access control: service allowlisting decides *which* APIs an agent can reach, request policies decide *what* it can do — denied requests never get real credentials. Tamper-evident audit logs with SHA-256 hash chains
+| Backend | Best For | Setup |
+|---------|----------|-------|
+| `keychain` | Local dev on macOS (default) | Works out of the box |
+| `encrypted-file` | Linux, WSL2, CI/CD | AES-256-GCM, password-protected |
+| `keepassxc` | Existing KeePass users | Set `AQUAMAN_KEEPASS_PASSWORD` or key file |
+| `1password` | Team credential sharing | `brew install 1password-cli && op signin` |
+| `vault` | Enterprise secrets management | Set `VAULT_ADDR` + `VAULT_TOKEN` |
+| `systemd-creds` | Linux with systemd ≥ 256 | TPM2-backed, no root required |
+| `bitwarden` | Bitwarden users | `bw login && export BW_SESSION=$(bw unlock --raw)` |
 
-**DevOps** — Plugs into Keychain, 1Password, HashiCorp Vault, and Bitwarden; YAML-based service config; 23 builtin services across 4 auth modes
+**Important:** `encrypted-file` is a last-resort backend for headless Linux/CI environments without a native keyring. For better security, install `libsecret-1-dev` (for GNOME Keyring), use `systemd-creds` (Linux with TPM2), or use 1Password/Vault.
 
-**Developers** — Transparent reverse proxy, no SDK changes, works with any OpenClaw workflow or standalone app
+## Security Audit
+
+`openclaw security audit --deep` reports two expected findings:
+
+- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the proxy as a separate process. This is how aquaman keeps credentials out of the agent.
+- **`tools_reachable_permissive_policy`** — OpenClaw warns that plugin tools (like `aquaman_status`) are reachable when no restrictive tool profile is set. This is an environment-level advisory about your agent's tool policy, not a vulnerability in aquaman. If your agents handle untrusted input, set `"tools": { "profile": "coding" }` in `openclaw.json` to restrict which tools agents can call.
+
+`aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Credential isolation for OpenClaw — secrets stay submerged, agents stay dry.
+Credential isolation for OpenClaw — secrets stay submerged, agents stay dry. Containers protect the host. Aquaman protects the credentials.
 
 You have bought yourself a brand new Mac Mini (or credits at your favorite cloud provider) and now you are still scared about your API credentials because you read all the articles. 
 
@@ -68,9 +68,10 @@ Agent / OpenClaw Gateway              Aquaman Proxy
 │  ANTHROPIC_BASE_URL  │══ Unix ════> │  Keychain / 1Pass /  │
 │  = aquaman.local     │   Domain     │  Vault / Encrypted   │
 │                      │<═ Socket ═══ │                      │
-│  fetch() interceptor │══ (UDS) ══=> │  + Auth injected:    │
-│  redirects channel   │              │    header / url-path │
-│  API traffic         │              │    basic / oauth     │
+│  fetch() interceptor │══ (UDS) ══=> │  + Policy enforced   │
+│  redirects channel   │              │  + Auth injected:    │
+│  API traffic         │              │    header / url-path │
+│                      │              │    basic / oauth     │
 │                      │              │                      │
 │  No credentials.     │  ~/.aquaman/ │                      │
 │  No open ports.      │  proxy.sock  │                      │
@@ -115,9 +116,58 @@ The agent only sees a sentinel hostname (`aquaman.local`). It never sees a key, 
 
 `aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.
 
+## Request Policies
+
+Aquaman has two layers of access control:
+
+1. **Service allowlisting** — `proxiedServices` controls *which services* the agent can reach at all. This is the perimeter.
+2. **Request policies** — per-service method + path rules control *which endpoints* the agent can call. This is the interior.
+
+OAuth scopes can't distinguish between "draft an email" and "send an email" — they're both `gmail.send`. Aquaman's request policies fill that gap: allow the service, then restrict what happens inside it.
+
+```yaml
+# ~/.aquaman/config.yaml
+policy:
+  anthropic:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/v1/organizations/**"
+        action: deny          # block admin/billing API
+  openai:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/v1/organization/**"
+        action: deny          # block admin API
+      - method: DELETE
+        path: "/v1/**"
+        action: deny          # no deletions
+  slack:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/admin.*"
+        action: deny          # block Slack admin methods
+  gmail:
+    defaultAction: allow
+    rules:
+      - method: POST
+        path: "/v1/users/*/messages/send"
+        action: deny          # drafts ok, sending blocked
+```
+
+**How it works:**
+- **No policy = allow all** (backward compatible)
+- **First match wins** — rules are evaluated top-to-bottom, unmatched requests fall through to `defaultAction`
+- **Denied before auth** — policy is checked before credential injection, so blocked requests never get real auth headers
+- **Path globs:** `*` matches within a segment (like shell glob), `**` matches zero or more path segments
+- **`aquaman setup`** applies safe defaults for stored services (blocks admin/billing endpoints)
+- **`aquaman doctor`** validates your policy config and warns about typos
+
 ## Why Aquaman
 
-**Security** — Process-level credential isolation via Unix domain socket (no TCP port, no network exposure). Socket file permissions (`chmod 600`) restrict access to the owning user. Tamper-evident audit logs with SHA-256 hash chains
+**Security** — Process-level credential isolation via Unix domain socket (no TCP port, no network exposure). Socket file permissions (`chmod 600`) restrict access to the owning user. Two-layer access control: service allowlisting decides *which* APIs an agent can reach, request policies decide *what* it can do — denied requests never get real credentials. Tamper-evident audit logs with SHA-256 hash chains
 
 **DevOps** — Plugs into Keychain, 1Password, HashiCorp Vault, and Bitwarden; YAML-based service config; 23 builtin services across 4 auth modes
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/tech4242/aquaman/actions/workflows/ci.yml/badge.svg)](https://github.com/tech4242/aquaman/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/tech4242/aquaman/branch/main/graph/badge.svg)](https://codecov.io/gh/tech4242/aquaman)
 [![npm version](https://img.shields.io/npm/v/aquaman-proxy?label=aquaman-proxy)](https://www.npmjs.com/package/aquaman-proxy)
-[![npm downloads](https://img.shields.io/npm/dm/aquaman-proxy)](https://www.npmjs.com/package/aquaman-proxy)
+[![npm downloads](https://img.shields.io/npm/dt/aquaman-proxy)](https://www.npmjs.com/package/aquaman-proxy)
 [![Security: process isolation](https://img.shields.io/badge/security-process%20isolation-critical)](https://github.com/tech4242/aquaman#security-model)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ policy:
 - **Denied before auth** — blocked requests never get real credentials
 - **Path globs:** `*` matches within a segment, `**` matches zero or more segments
 - **`aquaman setup`** applies safe defaults (blocks admin/billing endpoints for stored services)
+- **`aquaman policy list`** shows all configured rules; **`aquaman policy test <svc> <method> <path>`** dry-runs a request
 - **`aquaman doctor`** validates your policy config and warns about typos
 
 ## Credential Backends

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/openclaw:latest
 
 # Install aquaman proxy (includes credential stores, audit, CLI)
-RUN npm install -g aquaman-proxy@0.9.2
+RUN npm install -g aquaman-proxy@0.10.0
 
 # Install plugin into OpenClaw extensions
 RUN mkdir -p /home/node/.openclaw/extensions/aquaman-plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "description": "Credential isolation proxy for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞",
   "type": "module",

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,20 +1,19 @@
 # aquaman-plugin
 
-OpenClaw Gateway plugin for [aquaman](https://github.com/tech4242/aquaman) credential isolation.
-
-## How It Works
+OpenClaw Gateway plugin for [aquaman](https://github.com/tech4242/aquaman) — credential isolation for OpenClaw.
 
 ```
 Agent / OpenClaw Gateway              Aquaman Proxy
 ┌──────────────────────┐              ┌──────────────────────┐
 │                      │              │                      │
-│  ANTHROPIC_BASE_URL  │══ Unix ════>│  Keychain / 1Pass /  │
-│  = aquaman.local     │   Domain    │  Vault / Encrypted   │
-│                      │<═ Socket ═══│                      │
-│  fetch() interceptor │══ (UDS) ══=>│  + Policy enforced   │
+│  ANTHROPIC_BASE_URL  │══ Unix ═════>│  Keychain / 1Pass /  │
+│  = aquaman.local     │   Domain     │  Vault / Encrypted   │
+│                      │<═ Socket ════│                      │
+│  fetch() interceptor │══ (UDS) ════>│  + Policy enforced   │
 │  redirects channel   │              │  + Auth injected:    │
 │  API traffic         │              │    header / url-path │
 │                      │              │    basic / oauth     │
+│                      │              │                      │
 │  No credentials.     │  ~/.aquaman/ │                      │
 │  No open ports.      │  proxy.sock  │                      │
 │  Nothing to steal.   │  (chmod 600) │                      │
@@ -30,23 +29,21 @@ Agent / OpenClaw Gateway              Aquaman Proxy
                                slack.com/api  ...
 ```
 
-This plugin makes the left side work. It routes all LLM and channel API traffic through the aquaman proxy via Unix domain socket so credentials never enter the Gateway process. No TCP port is opened — traffic flows through `~/.aquaman/proxy.sock`.
+This plugin is the left side — it runs inside the Gateway process and routes all LLM and channel API traffic through the aquaman proxy via Unix domain socket. Credentials never enter the agent's address space.
+
+**What it does on load:**
+1. Sets `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` to `http://aquaman.local/<service>` (routed to UDS)
+2. Spawns the proxy daemon via `ProxyManager`
+3. Activates a `globalThis.fetch` interceptor to redirect channel API traffic through the proxy
+4. Registers `/aquaman-status` command and `aquaman_status` tool
 
 ## Quick Start
 
 ```bash
-npm install -g aquaman-proxy              # install the proxy CLI
-aquaman setup                             # stores keys, installs plugin, configures OpenClaw
-openclaw                                  # proxy starts automatically
+npm install -g aquaman-proxy
+aquaman setup                   # stores keys, installs this plugin, applies policy defaults
+openclaw                        # proxy starts automatically
 ```
-
-> `aquaman setup` auto-detects your credential backend. macOS defaults to Keychain,
-> Linux defaults to encrypted file. Override with `--backend`:
-> `aquaman setup --backend keepassxc`
-> Options: `keychain`, `encrypted-file`, `keepassxc`, `1password`, `vault`, `systemd-creds`, `bitwarden`
-
-Existing plaintext credentials are migrated automatically during setup.
-Run again anytime to migrate new credentials: `aquaman migrate openclaw --auto`
 
 Troubleshooting: `aquaman doctor`
 
@@ -59,26 +56,20 @@ Troubleshooting: `aquaman doctor`
 | `backend` | `"keychain"` \| `"1password"` \| `"vault"` \| `"encrypted-file"` \| `"keepassxc"` \| `"systemd-creds"` \| `"bitwarden"` | `"keychain"` | Credential store |
 | `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy |
 
-> Advanced settings (audit, vault) go in `~/.aquaman/config.yaml`.
+> Advanced settings (audit, vault, request policies) go in `~/.aquaman/config.yaml`. See [request policy docs](https://github.com/tech4242/aquaman#request-policies).
 
-## Request Policies
+## Security Audit
 
-Service allowlisting controls *which* APIs the agent can reach. Request policies add a second layer: *which endpoints* within those services. The proxy enforces method + path rules from `~/.aquaman/config.yaml` — denied requests return 403 before credentials are injected. `aquaman setup` applies safe defaults.
+`openclaw security audit --deep` reports two expected findings:
 
-See [main README](https://github.com/tech4242/aquaman#request-policies) for configuration details.
+- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the proxy as a separate process. This is how credential isolation works.
+- **`tools_reachable_permissive_policy`** — advisory about your tool policy, not an aquaman vulnerability. Set `"tools": { "profile": "coding" }` in `openclaw.json` if your agents handle untrusted input.
 
-## Security Audit Note
-
-Running `openclaw security audit --deep` will show two expected findings:
-
-- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the aquaman proxy as a separate process, which is the whole point of credential isolation.
-- **`tools_reachable_permissive_policy`** — advisory that plugin tools are reachable under the default tool policy. This is about your OpenClaw tool profile setting, not about aquaman. Set `"tools": { "profile": "coding" }` in `openclaw.json` if your agents handle untrusted input.
-
-`aquaman setup` adds the plugin to your `plugins.allow` trust list automatically.
+`aquaman setup` adds the plugin to `plugins.allow` automatically.
 
 ## Documentation
 
-See the [main README](https://github.com/tech4242/aquaman#readme) for architecture, Docker deployment, and manual testing.
+See the [main README](https://github.com/tech4242/aquaman#readme) for the full security model, architecture diagrams, and manual testing guides.
 
 ## License
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -11,10 +11,10 @@ Agent / OpenClaw Gateway              Aquaman Proxy
 │  ANTHROPIC_BASE_URL  │══ Unix ════>│  Keychain / 1Pass /  │
 │  = aquaman.local     │   Domain    │  Vault / Encrypted   │
 │                      │<═ Socket ═══│                      │
-│  fetch() interceptor │══ (UDS) ══=>│  + Auth injected:    │
-│  redirects channel   │              │    header / url-path │
-│  API traffic         │              │    basic / oauth     │
-│                      │              │                      │
+│  fetch() interceptor │══ (UDS) ══=>│  + Policy enforced   │
+│  redirects channel   │              │  + Auth injected:    │
+│  API traffic         │              │    header / url-path │
+│                      │              │    basic / oauth     │
 │  No credentials.     │  ~/.aquaman/ │                      │
 │  No open ports.      │  proxy.sock  │                      │
 │  Nothing to steal.   │  (chmod 600) │                      │
@@ -60,6 +60,12 @@ Troubleshooting: `aquaman doctor`
 | `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy |
 
 > Advanced settings (audit, vault) go in `~/.aquaman/config.yaml`.
+
+## Request Policies
+
+Service allowlisting controls *which* APIs the agent can reach. Request policies add a second layer: *which endpoints* within those services. The proxy enforces method + path rules from `~/.aquaman/config.yaml` — denied requests return 403 before credentials are injected. `aquaman setup` applies safe defaults.
+
+See [main README](https://github.com/tech4242/aquaman#request-policies) for configuration details.
 
 ## Security Audit Note
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-plugin",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Credential isolation plugin for OpenClaw",
   "type": "module",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.11",
-    "aquaman-proxy": "0.9.2"
+    "aquaman-proxy": "0.10.0"
   },
   "peerDependenciesMeta": {
     "aquaman-proxy": {

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,20 +1,19 @@
 # aquaman-proxy
 
-Credential isolation proxy and CLI for [aquaman](https://github.com/tech4242/aquaman).
-
-## How It Works
+The proxy daemon and CLI for [aquaman](https://github.com/tech4242/aquaman) — credential isolation for OpenClaw.
 
 ```
 Agent / OpenClaw Gateway              Aquaman Proxy
 ┌──────────────────────┐              ┌──────────────────────┐
 │                      │              │                      │
-│  ANTHROPIC_BASE_URL  │══ Unix ════>│  Keychain / 1Pass /  │
-│  = aquaman.local     │   Domain    │  Vault / Encrypted   │
-│                      │<═ Socket ═══│                      │
-│  fetch() interceptor │══ (UDS) ══=>│  + Policy enforced   │
+│  ANTHROPIC_BASE_URL  │══ Unix ═════>│  Keychain / 1Pass /  │
+│  = aquaman.local     │   Domain     │  Vault / Encrypted   │
+│                      │<═ Socket ════│                      │
+│  fetch() interceptor │══ (UDS) ════>│  + Policy enforced   │
 │  redirects channel   │              │  + Auth injected:    │
 │  API traffic         │              │    header / url-path │
 │                      │              │    basic / oauth     │
+│                      │              │                      │
 │  No credentials.     │  ~/.aquaman/ │                      │
 │  No open ports.      │  proxy.sock  │                      │
 │  Nothing to steal.   │  (chmod 600) │                      │
@@ -30,33 +29,22 @@ Agent / OpenClaw Gateway              Aquaman Proxy
                                slack.com/api  ...
 ```
 
-This package is the right side. A reverse proxy that listens on a Unix domain socket (`~/.aquaman/proxy.sock`) and injects credentials from secure backends. No TCP port, no network exposure. 25 builtin services, six auth modes.
+This package is the right side — a reverse proxy on a Unix domain socket that stores credentials in secure backends, enforces request policies, injects auth headers, and logs every access. The agent never sees a key.
 
 ## Quick Start
 
-With OpenClaw:
-
-```bash
-npm install -g aquaman-proxy              # install the proxy CLI
-aquaman setup                             # stores keys, installs plugin, configures OpenClaw
-openclaw                                  # proxy starts automatically via plugin
-```
-
-> `aquaman setup` auto-detects your credential backend. macOS defaults to Keychain,
-> Linux defaults to encrypted file. Override with `--backend`:
-> `aquaman setup --backend keepassxc`
-> Options: `keychain`, `encrypted-file`, `keepassxc`, `1password`, `vault`, `systemd-creds`, `bitwarden`
-
-Existing plaintext credentials are migrated automatically during setup.
-Run again anytime to migrate new credentials: `aquaman migrate openclaw --auto`
-
-Standalone:
-
 ```bash
 npm install -g aquaman-proxy
+aquaman setup                   # stores keys, installs OpenClaw plugin, applies policy defaults
+openclaw                        # proxy starts automatically via plugin
+```
+
+Standalone (without OpenClaw):
+
+```bash
 aquaman init
 aquaman credentials add anthropic api_key
-aquaman daemon                               # listens on ~/.aquaman/proxy.sock
+aquaman daemon                  # listens on ~/.aquaman/proxy.sock
 ```
 
 Troubleshooting: `aquaman doctor`
@@ -65,7 +53,7 @@ Troubleshooting: `aquaman doctor`
 
 | Command | Description |
 |---------|-------------|
-| `aquaman setup` | Guided onboarding (stores keys, installs plugin) |
+| `aquaman setup` | Guided onboarding (stores keys, installs plugin, applies policy defaults) |
 | `aquaman doctor` | Diagnose issues with actionable fixes |
 | `aquaman credentials add <svc> <key>` | Store a credential |
 | `aquaman credentials list` | List stored credentials |
@@ -88,26 +76,20 @@ Troubleshooting: `aquaman doctor`
 | **Channels (OAuth)** | MS Teams, Feishu, Google Chat |
 | **At-rest only** | Nostr, Tlon |
 
-## Request Policies
+## Security
 
-Service allowlisting controls *which* APIs the agent can reach. Request policies add a second layer: *which endpoints* within those services. Denied requests are blocked before credential injection.
+The proxy enforces four layers of protection:
 
-```yaml
-# ~/.aquaman/config.yaml
-policy:
-  anthropic:
-    defaultAction: allow
-    rules:
-      - method: "*"
-        path: "/v1/organizations/**"
-        action: deny
-```
+- **Process isolation** — credentials in a separate address space, connected via UDS (`chmod 600`)
+- **Service allowlisting** — `proxiedServices` controls which APIs the agent can reach
+- **Request policies** — method + path rules per service, checked *before* credential injection ([details](https://github.com/tech4242/aquaman#request-policies))
+- **Audit trail** — SHA-256 hash-chained logs of every credential use
 
-`aquaman setup` applies safe defaults. `aquaman doctor` validates policy config. See [main README](https://github.com/tech4242/aquaman#request-policies) for full docs.
+7 credential backends: Keychain, 1Password, Vault, Bitwarden, KeePassXC, systemd-creds, encrypted-file.
 
 ## Documentation
 
-See the [main README](https://github.com/tech4242/aquaman#readme) for architecture, credential backends, Docker deployment, and configuration.
+See the [main README](https://github.com/tech4242/aquaman#readme) for the full security model, request policy config, Docker deployment, and architecture diagrams.
 
 ## License
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -62,6 +62,8 @@ Troubleshooting: `aquaman doctor`
 | `aquaman start` | Start proxy + launch OpenClaw |
 | `aquaman stop` | Stop running proxy |
 | `aquaman status` | Show config and proxy status |
+| `aquaman policy list` | List configured policy rules |
+| `aquaman policy test <svc> <method> <path>` | Dry-run a request against policy rules |
 | `aquaman audit tail` | Recent audit entries |
 | `aquaman audit verify` | Verify hash chain integrity |
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -11,10 +11,10 @@ Agent / OpenClaw Gateway              Aquaman Proxy
 │  ANTHROPIC_BASE_URL  │══ Unix ════>│  Keychain / 1Pass /  │
 │  = aquaman.local     │   Domain    │  Vault / Encrypted   │
 │                      │<═ Socket ═══│                      │
-│  fetch() interceptor │══ (UDS) ══=>│  + Auth injected:    │
-│  redirects channel   │              │    header / url-path │
-│  API traffic         │              │    basic / oauth     │
-│                      │              │                      │
+│  fetch() interceptor │══ (UDS) ══=>│  + Policy enforced   │
+│  redirects channel   │              │  + Auth injected:    │
+│  API traffic         │              │    header / url-path │
+│                      │              │    basic / oauth     │
 │  No credentials.     │  ~/.aquaman/ │                      │
 │  No open ports.      │  proxy.sock  │                      │
 │  Nothing to steal.   │  (chmod 600) │                      │
@@ -87,6 +87,23 @@ Troubleshooting: `aquaman doctor`
 | **Channels (basic)** | Twilio, BlueBubbles, Nextcloud Talk |
 | **Channels (OAuth)** | MS Teams, Feishu, Google Chat |
 | **At-rest only** | Nostr, Tlon |
+
+## Request Policies
+
+Service allowlisting controls *which* APIs the agent can reach. Request policies add a second layer: *which endpoints* within those services. Denied requests are blocked before credential injection.
+
+```yaml
+# ~/.aquaman/config.yaml
+policy:
+  anthropic:
+    defaultAction: allow
+    rules:
+      - method: "*"
+        path: "/v1/organizations/**"
+        action: deny
+```
+
+`aquaman setup` applies safe defaults. `aquaman doctor` validates policy config. See [main README](https://github.com/tech4242/aquaman#request-policies) for full docs.
 
 ## Documentation
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-proxy",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Credential isolation proxy daemon for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -32,6 +32,7 @@ import { fileURLToPath } from 'node:url';
 import { createCredentialProxy, type CredentialProxy } from '../daemon.js';
 import { createServiceRegistry, ServiceRegistry } from '../service-registry.js';
 import { createOpenClawIntegration } from '../openclaw/integration.js';
+import { loadPolicyFromConfig, validatePolicyConfig, getDefaultPolicyPresets } from '../request-policy.js';
 import { stringify as yamlStringify, parse as yamlParse } from 'yaml';
 
 // Read version from package.json (single source of truth)
@@ -203,11 +204,13 @@ program
 
     // Start credential proxy
     const socketPath = path.join(getConfigDir(), 'proxy.sock');
+    const policyConfig = loadPolicyFromConfig(config);
     const credentialProxy = createCredentialProxy({
       socketPath,
       store: credentialStore,
       allowedServices: config.credentials.proxiedServices,
       serviceRegistry,
+      policyConfig,
       onRequest: (info) => {
         auditLogger.logCredentialAccess('system', 'system', {
           service: info.service,
@@ -377,11 +380,13 @@ program
     const serviceRegistry = createServiceRegistry({ configPath: config.services.configPath });
 
     // Start credential proxy
+    const policyConfig2 = loadPolicyFromConfig(config);
     const credentialProxy = createCredentialProxy({
       socketPath,
       store: credentialStore,
       allowedServices: config.credentials.proxiedServices,
       serviceRegistry,
+      policyConfig: policyConfig2,
       onRequest: (info) => {
         auditLogger.logCredentialAccess('system', 'system', {
           service: info.service,
@@ -459,11 +464,13 @@ program
     const serviceRegistry = createServiceRegistry({ configPath: config.services.configPath });
 
     // Start credential proxy
+    const policyConfig3 = loadPolicyFromConfig(config);
     const credentialProxy = createCredentialProxy({
       socketPath,
       store: credentialStore,
       allowedServices: config.credentials.proxiedServices,
       serviceRegistry,
+      policyConfig: policyConfig3,
       onRequest: (info) => {
         auditLogger.logCredentialAccess('system', 'system', {
           service: info.service,
@@ -569,6 +576,7 @@ program
   .description('All-in-one setup wizard — creates config, stores credentials, installs plugin')
   .option('--backend <backend>', 'Credential backend (keychain, encrypted-file, keepassxc, 1password, vault, systemd-creds, bitwarden)')
   .option('--no-openclaw', 'Skip OpenClaw plugin installation')
+  .option('--no-policy', 'Skip request policy preset configuration')
   .option('--non-interactive', 'Use environment variables instead of prompts (for CI)')
   .action(async (options) => {
     const os = await import('node:os');
@@ -835,6 +843,48 @@ program
         console.log('    \u2713 Stored openai/api_key\n');
       } else {
         console.log('    Skipped\n');
+      }
+    }
+
+    // 3.5. Apply request policy presets
+    if (options.policy !== false && storedServices.length > 0) {
+      let shouldApplyPolicy = true;
+
+      if (!isNonInteractive) {
+        const rl = (await import('node:readline')).createInterface({
+          input: process.stdin,
+          output: process.stdout
+        });
+        const answer = await new Promise<string>((resolve) => {
+          rl.question('  ? Enable API request policies? (Y/n): ', resolve);
+        });
+        rl.close();
+        shouldApplyPolicy = answer.toLowerCase() !== 'n';
+        if (shouldApplyPolicy) {
+          console.log('    Policies restrict which API endpoints agents can call.\n');
+        }
+      }
+
+      if (shouldApplyPolicy) {
+        const presets = getDefaultPolicyPresets();
+        const policyToApply: Record<string, any> = {};
+        for (const svc of storedServices) {
+          if (presets[svc]) {
+            policyToApply[svc] = presets[svc];
+          }
+        }
+
+        if (Object.keys(policyToApply).length > 0) {
+          config.policy = policyToApply;
+          saveConfig(config);
+
+          console.log('  Applying default policy presets:');
+          for (const svc of Object.keys(policyToApply)) {
+            console.log(`    \u2713 ${svc}: inference only (admin/billing endpoints denied)`);
+          }
+          console.log('');
+          console.log('  Customize policies later: ~/.aquaman/config.yaml\n');
+        }
       }
     }
 
@@ -1135,6 +1185,34 @@ program
           issues++;
         }
       }
+    }
+
+    // 5.5 Policy config
+    if (config?.policy && Object.keys(config.policy).length > 0) {
+      const policyConfigDoc = loadPolicyFromConfig(config);
+      const validation = validatePolicyConfig(policyConfigDoc);
+      if (validation.valid) {
+        const serviceCount = Object.keys(policyConfigDoc).length;
+        const ruleCount = Object.values(policyConfigDoc).reduce((sum, sp) => sum + sp.rules.length, 0);
+        console.log(`  \u2713 ${aqua('Policy')} valid (${serviceCount} service${serviceCount !== 1 ? 's' : ''}, ${ruleCount} rule${ruleCount !== 1 ? 's' : ''})`);
+        // Warn about policies for non-proxied services
+        if (config.credentials.proxiedServices) {
+          for (const svc of Object.keys(policyConfigDoc)) {
+            if (!config.credentials.proxiedServices.includes(svc)) {
+              console.log(`  \u26a0 ${aqua('Policy')} service "${svc}" has rules but is not in proxiedServices`);
+              issues++;
+            }
+          }
+        }
+      } else {
+        for (const err of validation.errors) {
+          console.log(`  \u2717 ${aqua('Policy')} ${err}`);
+        }
+        issues++;
+      }
+    } else {
+      console.log(`  \u2139 ${aqua('Policy')} not configured \u2014 agents can call any endpoint on proxied services`);
+      console.log('    \u2192 Run: aquaman setup (or add policy rules to ~/.aquaman/config.yaml)');
     }
 
     // 6. OpenClaw detection

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -32,7 +32,7 @@ import { fileURLToPath } from 'node:url';
 import { createCredentialProxy, type CredentialProxy } from '../daemon.js';
 import { createServiceRegistry, ServiceRegistry } from '../service-registry.js';
 import { createOpenClawIntegration } from '../openclaw/integration.js';
-import { loadPolicyFromConfig, validatePolicyConfig, getDefaultPolicyPresets } from '../request-policy.js';
+import { loadPolicyFromConfig, validatePolicyConfig, getDefaultPolicyPresets, matchPolicy, type ServicePolicy } from '../request-policy.js';
 import { stringify as yamlStringify, parse as yamlParse } from 'yaml';
 
 // Read version from package.json (single source of truth)
@@ -878,11 +878,11 @@ program
           config.policy = policyToApply;
           saveConfig(config);
 
-          console.log('  Applying default policy presets:');
-          for (const svc of Object.keys(policyToApply)) {
-            console.log(`    \u2713 ${svc}: inference only (admin/billing endpoints denied)`);
+          console.log('  Applying default policy presets:\n');
+          for (const [svc, sp] of Object.entries(policyToApply) as [string, ServicePolicy][]) {
+            console.log(formatServicePolicy(svc, sp, '    '));
+            console.log('');
           }
-          console.log('');
           console.log('  Customize policies later: ~/.aquaman/config.yaml\n');
         }
       }
@@ -1195,6 +1195,13 @@ program
         const serviceCount = Object.keys(policyConfigDoc).length;
         const ruleCount = Object.values(policyConfigDoc).reduce((sum, sp) => sum + sp.rules.length, 0);
         console.log(`  \u2713 ${aqua('Policy')} valid (${serviceCount} service${serviceCount !== 1 ? 's' : ''}, ${ruleCount} rule${ruleCount !== 1 ? 's' : ''})`);
+        for (const [svc, sp] of Object.entries(policyConfigDoc)) {
+          const denyRules = sp.rules.filter(r => r.action === 'deny');
+          if (denyRules.length > 0) {
+            const summary = denyRules.map(r => r.method !== '*' ? `${r.action} ${r.method} ${r.path}` : `${r.action} ${r.path}`).join(', ');
+            console.log(`      ${svc}: ${summary}`);
+          }
+        }
         // Warn about policies for non-proxied services
         if (config.credentials.proxiedServices) {
           for (const svc of Object.keys(policyConfigDoc)) {
@@ -1756,6 +1763,49 @@ services
     }
   });
 
+// Policy commands
+const policy = program.command('policy').description('Request policy management');
+
+policy
+  .command('list')
+  .description('List configured policy rules')
+  .action(async () => {
+    const config = loadConfig();
+    const policyConfig = loadPolicyFromConfig(config);
+
+    if (Object.keys(policyConfig).length === 0) {
+      console.log('No policies configured. Run: aquaman setup');
+      return;
+    }
+
+    for (const [name, sp] of Object.entries(policyConfig)) {
+      console.log(formatServicePolicy(name, sp));
+    }
+  });
+
+policy
+  .command('test <service> <method> <path>')
+  .description('Test whether a request would be allowed or denied')
+  .action(async (service: string, method: string, reqPath: string) => {
+    const config = loadConfig();
+    const policyConfig = loadPolicyFromConfig(config);
+
+    const result = matchPolicy(service, method.toUpperCase(), reqPath, policyConfig);
+
+    if (!policyConfig[service]) {
+      console.log(`  \u2713 ALLOWED (no policy for service "${service}")`);
+      return;
+    }
+
+    if (result.allowed) {
+      const svcPolicy = policyConfig[service];
+      console.log(`  \u2713 ALLOWED (no matching rule, default: ${svcPolicy.defaultAction})`);
+    } else {
+      const rule = result.matchedRule!;
+      console.log(`  \u2717 DENIED by rule: ${rule.method} ${rule.path} \u2192 ${rule.action}`);
+    }
+  });
+
 // Migration commands
 const migrate = program.command('migrate').description('Migrate credentials from other sources');
 
@@ -2217,6 +2267,19 @@ program
       console.log(`  - ${service}`);
     }
 
+    // Policy summary
+    const policyConfig = loadPolicyFromConfig(config);
+    const policySvcCount = Object.keys(policyConfig).length;
+    if (policySvcCount > 0) {
+      const ruleCount = Object.values(policyConfig).reduce((sum, sp) => sum + sp.rules.length, 0);
+      console.log(`\nRequest policies: ${policySvcCount} service${policySvcCount !== 1 ? 's' : ''}, ${ruleCount} rule${ruleCount !== 1 ? 's' : ''}`);
+      for (const [svc, sp] of Object.entries(policyConfig)) {
+        console.log(`  - ${svc}: ${sp.rules.length} rule${sp.rules.length !== 1 ? 's' : ''} (default: ${sp.defaultAction})`);
+      }
+    } else {
+      console.log('\nRequest policies: not configured');
+    }
+
     // Check for stored credentials
     try {
       const store = await createCredentialStore({
@@ -2249,6 +2312,17 @@ program
     console.log(`\nOpenClaw: ${info.installed ? `installed (${info.version})` : 'not found'}`);
   });
 
+/** Format a single service policy for display (used by policy list, setup, doctor) */
+function formatServicePolicy(name: string, sp: ServicePolicy, indent = '  '): string {
+  const lines: string[] = [];
+  lines.push(`${indent}${name} (default: ${sp.defaultAction})`);
+  for (const rule of sp.rules) {
+    const method = rule.method.padEnd(6);
+    lines.push(`${indent}  ${rule.action === 'deny' ? 'deny' : 'allow'}  ${method} ${rule.path}`);
+  }
+  return lines.join('\n');
+}
+
 function formatEntry(entry: any): string {
   switch (entry.type) {
     case 'tool_call':
@@ -2256,7 +2330,7 @@ function formatEntry(entry: any): string {
     case 'tool_result':
       return `Result for ${entry.data.toolCallId}`;
     case 'credential_access':
-      return `${entry.data.service} ${entry.data.operation} ${entry.data.success ? 'OK' : 'FAIL'}`;
+      return `${entry.data.service} ${entry.data.operation} ${entry.data.success ? 'OK' : `FAIL: ${entry.data.error || 'unknown'}`}`;
     default:
       return JSON.stringify(entry.data).slice(0, 80);
   }

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -47,6 +47,15 @@ const noColor = process.env['NO_COLOR'] !== undefined ||
                 (!process.stdout.isTTY && process.env['FORCE_COLOR'] === undefined);
 const aqua = (s: string) => noColor ? s : `\x1b[38;2;127;255;212m${s}\x1b[0m`;
 
+// Credential name validation — shared pattern from daemon.ts and systemd-creds backend
+const SAFE_CRED_NAME = /^[a-z0-9][a-z0-9._-]*$/;
+function validateCredName(label: string, value: string): void {
+  if (!SAFE_CRED_NAME.test(value)) {
+    console.error(`Invalid ${label}: "${value}". Allowed: lowercase alphanumeric, dots, hyphens, underscores.`);
+    process.exit(1);
+  }
+}
+
 // PID file management
 const getPidFile = () => path.join(getConfigDir(), 'daemon.pid');
 
@@ -1494,6 +1503,9 @@ credentials
   .description('Add a credential')
   .option('--backend <backend>', 'Override credential backend')
   .action(async (service: string, key: string, options) => {
+    validateCredName('service', service);
+    validateCredName('key', key);
+
     const config = loadConfig();
     const backend = options.backend || config.credentials.backend;
 
@@ -1596,6 +1608,9 @@ credentials
   .command('delete <service> <key>')
   .description('Delete a credential')
   .action(async (service: string, key: string) => {
+    validateCredName('service', service);
+    validateCredName('key', key);
+
     const config = loadConfig();
     let store;
     try {

--- a/packages/proxy/src/core/credentials/backends/vault.ts
+++ b/packages/proxy/src/core/credentials/backends/vault.ts
@@ -14,6 +14,7 @@ export interface VaultStoreOptions {
 
 const DEFAULT_MOUNT_PATH = 'secret';
 const AQUAMAN_PATH_PREFIX = 'aquaman';
+const SAFE_CRED_NAME = /^[a-z0-9][a-z0-9._-]*$/;
 
 export class VaultStore implements CredentialStore {
   private address: string;
@@ -36,7 +37,15 @@ export class VaultStore implements CredentialStore {
     }
   }
 
+  private validateName(label: string, value: string): void {
+    if (!SAFE_CRED_NAME.test(value)) {
+      throw new Error(`Invalid ${label} name: "${value}". Allowed pattern: ${SAFE_CRED_NAME.source}`);
+    }
+  }
+
   private getPath(service: string, key: string): string {
+    this.validateName('service', service);
+    this.validateName('key', key);
     return `${AQUAMAN_PATH_PREFIX}/${service}/${key}`;
   }
 

--- a/packages/proxy/src/core/types.ts
+++ b/packages/proxy/src/core/types.ts
@@ -95,6 +95,7 @@ export interface WrapperConfig {
   audit: AuditConfig;
   services: ServicesConfig;
   openclaw: OpenClawConfig;
+  policy?: Record<string, { defaultAction: 'allow' | 'deny'; rules: Array<{ method: string; path: string; action: 'allow' | 'deny' }> }>;
 }
 
 export type CredentialBackend = 'keychain' | '1password' | 'vault' | 'encrypted-file' | 'keepassxc' | 'systemd-creds' | 'bitwarden';

--- a/packages/proxy/src/core/utils/config.ts
+++ b/packages/proxy/src/core/utils/config.ts
@@ -153,7 +153,8 @@ function mergeConfig(
     openclaw: {
       ...base.openclaw,
       ...override.openclaw
-    }
+    },
+    policy: override.policy !== undefined ? { ...base.policy, ...override.policy } : base.policy
   };
 }
 

--- a/packages/proxy/src/daemon.ts
+++ b/packages/proxy/src/daemon.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { type CredentialStore, generateId } from './core/index.js';
 import { ServiceRegistry, createServiceRegistry, type ServiceDefinition, type AuthMode } from './service-registry.js';
 import { OAuthTokenCache, createOAuthTokenCache } from './oauth-token-cache.js';
+import { matchPolicy, type PolicyConfig } from './request-policy.js';
 
 // Service name validation: lowercase alphanum, dots, hyphens, underscores
 const SAFE_SERVICE_NAME = /^[a-z0-9][a-z0-9._-]*$/;
@@ -29,6 +30,7 @@ export interface CredentialProxyOptions {
   onRequest?: (info: RequestInfo) => void;
   serviceRegistry?: ServiceRegistry;
   requestTimeout?: number; // Upstream request timeout in ms, defaults to 30000 (30s)
+  policyConfig?: PolicyConfig;
 }
 
 export interface RequestInfo {
@@ -172,6 +174,8 @@ export class CredentialProxy {
       credentialKey: serviceDef.credentialKey
     };
 
+    const remainingPath = '/' + pathParts.slice(1).join('/');
+
     const requestInfo: RequestInfo = {
       id: requestId,
       service,
@@ -180,6 +184,23 @@ export class CredentialProxy {
       timestamp: new Date(),
       authenticated: false
     };
+
+    // Policy check — before credential retrieval
+    if (this.options.policyConfig) {
+      const policyResult = matchPolicy(service, req.method || 'GET', remainingPath, this.options.policyConfig);
+      if (!policyResult.allowed) {
+        requestInfo.error = `Policy denied: ${req.method || 'GET'} ${remainingPath}`;
+        requestInfo.statusCode = 403;
+        this.emitRequest(requestInfo);
+        res.setHeader('Content-Type', 'application/json');
+        res.statusCode = 403;
+        res.end(JSON.stringify({
+          error: `Request denied by policy: ${req.method || 'GET'} ${url}`,
+          fix: `Check policy rules for "${service}" in ~/.aquaman/config.yaml`
+        }));
+        return;
+      }
+    }
 
     try {
       // Get primary credential from store
@@ -201,7 +222,6 @@ export class CredentialProxy {
       requestInfo.authenticated = true;
 
       // Build upstream URL based on auth mode
-      const remainingPath = '/' + pathParts.slice(1).join('/');
       let upstreamPath: string;
 
       if (authMode === 'url-path' && serviceDef.authPathTemplate) {

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -48,5 +48,17 @@ export {
   createOpenClawIntegration
 } from './openclaw/integration.js';
 
+// Request Policy
+export {
+  type PolicyRule,
+  type ServicePolicy,
+  type PolicyConfig,
+  matchPathPattern,
+  matchPolicy,
+  loadPolicyFromConfig,
+  validatePolicyConfig,
+  getDefaultPolicyPresets
+} from './request-policy.js';
+
 // Core (merged from aquaman-core)
 export * from './core/index.js';

--- a/packages/proxy/src/oauth-token-cache.ts
+++ b/packages/proxy/src/oauth-token-cache.ts
@@ -77,6 +77,9 @@ export class OAuthTokenCache {
     let tokenUrl = config.tokenUrl;
     const templateMatch = tokenUrl.match(/\{(\w+)\}/g);
     if (templateMatch) {
+      // Capture original hostname before template resolution for SSRF prevention
+      const originalHost = new URL(config.tokenUrl.replace(/\{\w+\}/g, 'placeholder')).hostname;
+
       for (const placeholder of templateMatch) {
         const key = placeholder.slice(1, -1);
         const value = await store.get(service, key);
@@ -84,6 +87,21 @@ export class OAuthTokenCache {
           throw new Error(`OAuth token URL requires credential "${key}" for service ${service}`);
         }
         tokenUrl = tokenUrl.replace(placeholder, value);
+      }
+
+      // Validate resolved URL hostname hasn't changed (prevents SSRF via credential store poisoning)
+      try {
+        const resolvedHost = new URL(tokenUrl).hostname;
+        if (resolvedHost !== originalHost) {
+          throw new Error(
+            `OAuth token URL hostname changed after template resolution for ${service}: expected "${originalHost}", got "${resolvedHost}"`
+          );
+        }
+      } catch (e) {
+        if (e instanceof TypeError) {
+          throw new Error(`OAuth token URL is not a valid URL after template resolution for ${service}: ${tokenUrl}`);
+        }
+        throw e;
       }
     }
 

--- a/packages/proxy/src/openclaw/env-writer.ts
+++ b/packages/proxy/src/openclaw/env-writer.ts
@@ -12,6 +12,9 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import type { ServiceConfig } from '../core/index.js';
 
+/** Matches the SAFE_SERVICE_NAME pattern from daemon.ts — prevents shell injection in export statements */
+const SAFE_SERVICE_NAME = /^[a-z0-9][a-z0-9._-]*$/;
+
 export interface EnvConfig {
   services: ServiceConfig[];
 }
@@ -26,6 +29,9 @@ export function generateOpenClawEnv(config: EnvConfig): Record<string, string> {
 
   // For each service, set the base URL to point to our sentinel hostname
   for (const service of config.services) {
+    if (!SAFE_SERVICE_NAME.test(service.name)) {
+      continue; // Skip services with unsafe names — prevents shell injection in RC files
+    }
     const baseUrl = `http://aquaman.local/${service.name}`;
 
     // Map service names to OpenClaw environment variables

--- a/packages/proxy/src/request-policy.ts
+++ b/packages/proxy/src/request-policy.ts
@@ -1,0 +1,191 @@
+/**
+ * Request-level policy enforcement for aquaman proxy
+ *
+ * Evaluates method + path rules per service before credential injection.
+ * Denied requests never get real credentials.
+ */
+
+export interface PolicyRule {
+  method: string;
+  path: string;
+  action: 'allow' | 'deny';
+}
+
+export interface ServicePolicy {
+  defaultAction: 'allow' | 'deny';
+  rules: PolicyRule[];
+}
+
+export type PolicyConfig = Record<string, ServicePolicy>;
+
+/**
+ * Match a glob pattern against a URL path using segment-based matching.
+ *
+ * - `**` matches zero or more whole path segments
+ * - `*` within a segment is a substring wildcard (shell-glob style):
+ *   `admin.*` matches `admin.users.list`
+ * - An exact segment `foo` matches only `foo`
+ */
+export function matchPathPattern(pattern: string, urlPath: string): boolean {
+  // Normalize: strip leading slash, split on /
+  const patternParts = pattern.replace(/^\//, '').replace(/\/$/, '').split('/').filter(Boolean);
+  const pathParts = urlPath.replace(/^\//, '').replace(/\/$/, '').split('/').filter(Boolean);
+
+  return matchSegments(patternParts, 0, pathParts, 0);
+}
+
+function matchSegments(
+  pattern: string[], pi: number,
+  path: string[], si: number
+): boolean {
+  while (pi < pattern.length && si < path.length) {
+    const seg = pattern[pi];
+
+    if (seg === '**') {
+      // ** matches zero or more whole segments
+      // Try matching the rest of pattern against every suffix of path
+      for (let skip = si; skip <= path.length; skip++) {
+        if (matchSegments(pattern, pi + 1, path, skip)) return true;
+      }
+      return false;
+    }
+
+    // Match single segment (may contain * as substring wildcard)
+    if (!matchSegment(seg, path[si])) return false;
+    pi++;
+    si++;
+  }
+
+  // Consume trailing ** patterns (they match zero segments)
+  while (pi < pattern.length && pattern[pi] === '**') pi++;
+
+  return pi === pattern.length && si === path.length;
+}
+
+function matchSegment(pattern: string, segment: string): boolean {
+  if (pattern === '*') return true;
+  if (!pattern.includes('*')) return pattern === segment;
+
+  // Convert segment pattern to regex: * → .*
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`).test(segment);
+}
+
+/**
+ * Evaluate policy for a request. Returns whether the request is allowed
+ * and the rule that matched (if any).
+ *
+ * First-match-wins: rules are evaluated top-to-bottom.
+ * If no rule matches, defaultAction applies.
+ */
+export function matchPolicy(
+  service: string,
+  method: string,
+  remainingPath: string,
+  config: PolicyConfig
+): { allowed: boolean; matchedRule?: PolicyRule } {
+  const servicePolicy = config[service];
+  if (!servicePolicy) {
+    return { allowed: true };
+  }
+
+  for (const rule of servicePolicy.rules) {
+    const methodMatches = rule.method === '*' || rule.method.toUpperCase() === method.toUpperCase();
+    if (!methodMatches) continue;
+
+    if (matchPathPattern(rule.path, remainingPath)) {
+      return {
+        allowed: rule.action === 'allow',
+        matchedRule: rule
+      };
+    }
+  }
+
+  return {
+    allowed: servicePolicy.defaultAction === 'allow'
+  };
+}
+
+/**
+ * Extract and return PolicyConfig from a WrapperConfig's policy field.
+ * Returns empty config if no policy is set.
+ */
+export function loadPolicyFromConfig(config: { policy?: Record<string, any> }): PolicyConfig {
+  if (!config.policy) return {};
+
+  const result: PolicyConfig = {};
+  for (const [service, sp] of Object.entries(config.policy)) {
+    result[service] = {
+      defaultAction: sp.defaultAction === 'deny' ? 'deny' : 'allow',
+      rules: Array.isArray(sp.rules) ? sp.rules.map((r: any) => ({
+        method: String(r.method || '*'),
+        path: String(r.path || '/'),
+        action: r.action === 'allow' ? 'allow' : 'deny'
+      })) : []
+    };
+  }
+  return result;
+}
+
+/**
+ * Validate a PolicyConfig. Returns errors for invalid rules.
+ */
+export function validatePolicyConfig(policy: PolicyConfig): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  for (const [service, sp] of Object.entries(policy)) {
+    if (sp.defaultAction !== 'allow' && sp.defaultAction !== 'deny') {
+      errors.push(`service "${service}" has invalid defaultAction "${sp.defaultAction}" (expected "allow" or "deny")`);
+    }
+
+    for (let i = 0; i < sp.rules.length; i++) {
+      const rule = sp.rules[i];
+      if (rule.action !== 'allow' && rule.action !== 'deny') {
+        errors.push(`rule ${i + 1} for "${service}" has unknown action "${rule.action}" (expected "allow" or "deny")`);
+      }
+      if (!rule.path.startsWith('/')) {
+        errors.push(`rule ${i + 1} for "${service}" has path "${rule.path}" that doesn't start with /`);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Default policy presets for common services. Conservative: default-allow
+ * with specific denies for dangerous admin/billing/send endpoints.
+ */
+export function getDefaultPolicyPresets(): Record<string, ServicePolicy> {
+  return {
+    anthropic: {
+      defaultAction: 'allow',
+      rules: [
+        // Anthropic Admin API: /v1/organizations/{org_id}/... manages API keys, users, workspaces, billing
+        { method: '*', path: '/v1/organizations/**', action: 'deny' },
+      ]
+    },
+    openai: {
+      defaultAction: 'allow',
+      rules: [
+        // OpenAI Admin API: /v1/organization/... manages admin keys, users, projects
+        { method: '*', path: '/v1/organization/**', action: 'deny' },
+        { method: 'DELETE', path: '/v1/**', action: 'deny' },
+      ]
+    },
+    gmail: {
+      defaultAction: 'allow',
+      rules: [
+        // Gmail send: POST /gmail/v1/users/{userId}/messages/send
+        { method: 'POST', path: '/v1/users/*/messages/send', action: 'deny' },
+      ]
+    },
+    slack: {
+      defaultAction: 'allow',
+      rules: [
+        // Slack admin methods: /admin.users.list, /admin.conversations.create, etc.
+        { method: '*', path: '/admin.*', action: 'deny' },
+      ]
+    }
+  };
+}

--- a/test/e2e/cli-policy.test.ts
+++ b/test/e2e/cli-policy.test.ts
@@ -1,0 +1,177 @@
+/**
+ * E2E tests for `aquaman policy list` and `aquaman policy test` commands.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { writeFileSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { createTempEnv, type TempEnv } from '../helpers/temp-env.js';
+
+const CLI_PATH = path.resolve('packages/proxy/src/cli/index.ts');
+const TEST_TIMEOUT = 30_000;
+
+function runCli(
+  args: string,
+  tempEnv: TempEnv,
+): { stdout: string; stderr: string; exitCode: number | null } {
+  try {
+    const stdout = execSync(`npx tsx ${CLI_PATH} ${args}`, {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        ...tempEnv.env,
+      },
+      timeout: 20_000,
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+/** Write a config.yaml with policy rules into the temp env */
+function writeConfigWithPolicy(tempEnv: TempEnv): void {
+  const configPath = path.join(tempEnv.aquamanDir, 'config.yaml');
+  const existing = readFileSync(configPath, 'utf-8');
+  writeFileSync(
+    configPath,
+    existing + [
+      'policy:',
+      '  anthropic:',
+      '    defaultAction: allow',
+      '    rules:',
+      '      - method: "*"',
+      '        path: "/v1/organizations/**"',
+      '        action: deny',
+      '  openai:',
+      '    defaultAction: allow',
+      '    rules:',
+      '      - method: "*"',
+      '        path: "/v1/organization/**"',
+      '        action: deny',
+      '      - method: DELETE',
+      '        path: "/v1/**"',
+      '        action: deny',
+      '  slack:',
+      '    defaultAction: allow',
+      '    rules:',
+      '      - method: "*"',
+      '        path: "/admin.*"',
+      '        action: deny',
+      '',
+    ].join('\n'),
+    'utf-8'
+  );
+}
+
+describe('aquaman policy E2E', () => {
+  let tempEnv: TempEnv;
+
+  afterEach(() => {
+    if (tempEnv) tempEnv.cleanup();
+  });
+
+  describe('policy list', () => {
+    it('shows rules when policies are configured', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+      writeConfigWithPolicy(tempEnv);
+
+      const { stdout, exitCode } = runCli('policy list', tempEnv);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('anthropic (default: allow)');
+      expect(stdout).toContain('deny');
+      expect(stdout).toContain('/v1/organizations/**');
+      expect(stdout).toContain('openai (default: allow)');
+      expect(stdout).toContain('/v1/organization/**');
+      expect(stdout).toContain('slack (default: allow)');
+      expect(stdout).toContain('/admin.*');
+    }, TEST_TIMEOUT);
+
+    it('shows "not configured" when no policies exist', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+
+      const { stdout, exitCode } = runCli('policy list', tempEnv);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('No policies configured');
+      expect(stdout).toContain('aquaman setup');
+    }, TEST_TIMEOUT);
+  });
+
+  describe('policy test', () => {
+    it('shows DENIED for matching deny rule', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+      writeConfigWithPolicy(tempEnv);
+
+      const { stdout, exitCode } = runCli(
+        'policy test anthropic GET /v1/organizations/org123/members',
+        tempEnv
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('DENIED');
+      expect(stdout).toContain('/v1/organizations/**');
+    }, TEST_TIMEOUT);
+
+    it('shows ALLOWED when no rule matches', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+      writeConfigWithPolicy(tempEnv);
+
+      const { stdout, exitCode } = runCli(
+        'policy test anthropic POST /v1/messages',
+        tempEnv
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('ALLOWED');
+      expect(stdout).toContain('default: allow');
+    }, TEST_TIMEOUT);
+
+    it('shows DENIED for DELETE on openai', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+      writeConfigWithPolicy(tempEnv);
+
+      const { stdout, exitCode } = runCli(
+        'policy test openai DELETE /v1/files/file-abc',
+        tempEnv
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('DENIED');
+    }, TEST_TIMEOUT);
+
+    it('shows DENIED for slack admin method', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+      writeConfigWithPolicy(tempEnv);
+
+      const { stdout, exitCode } = runCli(
+        'policy test slack POST /admin.users.list',
+        tempEnv
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('DENIED');
+      expect(stdout).toContain('/admin.*');
+    }, TEST_TIMEOUT);
+
+    it('shows ALLOWED for unknown service', () => {
+      tempEnv = createTempEnv({ withConfig: true });
+      writeConfigWithPolicy(tempEnv);
+
+      const { stdout, exitCode } = runCli(
+        'policy test unknown-service GET /foo',
+        tempEnv
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('ALLOWED');
+      expect(stdout).toContain('no policy');
+    }, TEST_TIMEOUT);
+  });
+});

--- a/test/e2e/request-policy.test.ts
+++ b/test/e2e/request-policy.test.ts
@@ -1,0 +1,204 @@
+/**
+ * E2E tests for request-level policy enforcement through the full proxy stack.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createCredentialProxy, type CredentialProxy, type PolicyConfig } from 'aquaman-proxy';
+import { MemoryStore } from 'aquaman-core';
+import type { RequestInfo } from 'aquaman-proxy';
+import { tmpSocketPath, cleanupSocket, udsFetch } from '../helpers/uds-proxy.js';
+
+describe('Request policy enforcement E2E', () => {
+  let proxy: CredentialProxy;
+  let store: MemoryStore;
+  let requestLog: RequestInfo[];
+  let socketPath: string;
+
+  afterEach(async () => {
+    if (proxy?.isRunning()) await proxy.stop();
+    store?.clear();
+    if (socketPath) cleanupSocket(socketPath);
+  });
+
+  async function startProxy(policyConfig?: PolicyConfig) {
+    store = new MemoryStore();
+    requestLog = [];
+    socketPath = tmpSocketPath();
+
+    await store.set('anthropic', 'api_key', 'sk-ant-test-key');
+    await store.set('openai', 'api_key', 'sk-openai-test-key');
+    await store.set('slack', 'bot_token', 'xoxb-test-token');
+
+    proxy = createCredentialProxy({
+      socketPath,
+      store,
+      allowedServices: ['anthropic', 'openai', 'slack'],
+      policyConfig,
+      onRequest: (info) => {
+        requestLog.push(info);
+      }
+    });
+
+    await proxy.start();
+  }
+
+  it('no policy configured allows all requests (backward compat)', async () => {
+    await startProxy(undefined);
+
+    const res = await udsFetch(socketPath, '/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'test', messages: [] }),
+    });
+
+    // Should reach upstream (will fail with connection error or timeout, not 403)
+    expect(res.status).not.toBe(403);
+  });
+
+  it('denied request returns 403 with JSON error and fix', async () => {
+    const policy: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+      }
+    };
+    await startProxy(policy);
+
+    const res = await udsFetch(socketPath, '/anthropic/v1/organizations/org123/members', {
+      method: 'GET',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.headers['content-type']).toBe('application/json');
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain('denied by policy');
+    expect(body.fix).toContain('anthropic');
+    expect(body.fix).toContain('config.yaml');
+  });
+
+  it('denied request is logged via onRequest with error', async () => {
+    const policy: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+      }
+    };
+    await startProxy(policy);
+
+    await udsFetch(socketPath, '/anthropic/v1/organizations/org123', { method: 'GET' });
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].statusCode).toBe(403);
+    expect(requestLog[0].authenticated).toBe(false);
+    expect(requestLog[0].error).toContain('Policy denied');
+  });
+
+  it('allowed request proceeds normally', async () => {
+    const policy: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+      }
+    };
+    await startProxy(policy);
+
+    const res = await udsFetch(socketPath, '/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'test', messages: [] }),
+    });
+
+    // Should NOT be blocked by policy - may fail upstream but not with 403
+    expect(res.status).not.toBe(403);
+  });
+
+  it('allowedServices 404 takes precedence over policy 403', async () => {
+    const policy: PolicyConfig = {
+      unknown: {
+        defaultAction: 'deny',
+        rules: []
+      }
+    };
+    await startProxy(policy);
+
+    // 'unknown' is not in allowedServices, should get 404 not 403
+    const res = await udsFetch(socketPath, '/unknown/v1/test', { method: 'GET' });
+    expect(res.status).toBe(404);
+  });
+
+  it('default-deny blocks unmatched requests', async () => {
+    const policy: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'deny',
+        rules: [{ method: 'POST', path: '/v1/messages', action: 'allow' }]
+      }
+    };
+    await startProxy(policy);
+
+    // GET /v1/messages doesn't match the POST rule, falls to default deny
+    const res = await udsFetch(socketPath, '/anthropic/v1/messages', { method: 'GET' });
+    expect(res.status).toBe(403);
+  });
+
+  it('default-deny with matching allow rule permits request', async () => {
+    const policy: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'deny',
+        rules: [{ method: 'POST', path: '/v1/messages', action: 'allow' }]
+      }
+    };
+    await startProxy(policy);
+
+    const res = await udsFetch(socketPath, '/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'test', messages: [] }),
+    });
+
+    // Should pass policy (may fail upstream but not 403)
+    expect(res.status).not.toBe(403);
+  });
+
+  it('Slack admin methods denied by preset', async () => {
+    const policy: PolicyConfig = {
+      slack: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/admin.*', action: 'deny' }]
+      }
+    };
+    await startProxy(policy);
+
+    const res = await udsFetch(socketPath, '/slack/admin.users.list', { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+
+  it('Slack normal methods allowed by preset', async () => {
+    const policy: PolicyConfig = {
+      slack: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/admin.*', action: 'deny' }]
+      }
+    };
+    await startProxy(policy);
+
+    const res = await udsFetch(socketPath, '/slack/auth.test', { method: 'POST' });
+    // Not blocked by policy
+    expect(res.status).not.toBe(403);
+  });
+
+  it('DELETE denied by openai preset', async () => {
+    const policy: PolicyConfig = {
+      openai: {
+        defaultAction: 'allow',
+        rules: [
+          { method: '*', path: '/v1/organization/**', action: 'deny' },
+          { method: 'DELETE', path: '/v1/**', action: 'deny' },
+        ]
+      }
+    };
+    await startProxy(policy);
+
+    const res = await udsFetch(socketPath, '/openai/v1/files/file-abc', { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/test/unit/request-policy.test.ts
+++ b/test/unit/request-policy.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for request-level policy enforcement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  matchPathPattern,
+  matchPolicy,
+  validatePolicyConfig,
+  loadPolicyFromConfig,
+  getDefaultPolicyPresets,
+  type PolicyConfig,
+  type ServicePolicy
+} from 'aquaman-proxy';
+
+describe('matchPathPattern', () => {
+  it('matches exact path', () => {
+    expect(matchPathPattern('/v1/messages', '/v1/messages')).toBe(true);
+  });
+
+  it('rejects different path', () => {
+    expect(matchPathPattern('/v1/messages', '/v1/completions')).toBe(false);
+  });
+
+  it('matches single-segment wildcard *', () => {
+    expect(matchPathPattern('/v1/users/*/drafts', '/v1/users/me/drafts')).toBe(true);
+    expect(matchPathPattern('/v1/users/*/drafts', '/v1/users/alice@example.com/drafts')).toBe(true);
+  });
+
+  it('single * does not match across segments', () => {
+    expect(matchPathPattern('/v1/users/*/drafts', '/v1/users/a/b/drafts')).toBe(false);
+  });
+
+  it('matches multi-segment wildcard **', () => {
+    expect(matchPathPattern('/v1/organizations/**', '/v1/organizations/foo/bar')).toBe(true);
+    expect(matchPathPattern('/v1/organizations/**', '/v1/organizations/foo')).toBe(true);
+    expect(matchPathPattern('/v1/organizations/**', '/v1/organizations')).toBe(true);
+  });
+
+  it('** matches zero segments', () => {
+    expect(matchPathPattern('/v1/**', '/v1')).toBe(true);
+  });
+
+  it('substring wildcard within segment (admin.*)', () => {
+    expect(matchPathPattern('/admin.*', '/admin.users.list')).toBe(true);
+    expect(matchPathPattern('/admin.*', '/admin.conversations.create')).toBe(true);
+  });
+
+  it('exact segment does NOT match partial', () => {
+    expect(matchPathPattern('/admin', '/admin.users')).toBe(false);
+  });
+
+  it('handles trailing slashes', () => {
+    expect(matchPathPattern('/v1/messages/', '/v1/messages')).toBe(true);
+    expect(matchPathPattern('/v1/messages', '/v1/messages/')).toBe(true);
+  });
+
+  it('matches root path', () => {
+    expect(matchPathPattern('/', '/')).toBe(true);
+  });
+
+  it('** at end matches deep paths', () => {
+    expect(matchPathPattern('/v1/**', '/v1/foo/bar/baz/qux')).toBe(true);
+  });
+});
+
+describe('matchPolicy', () => {
+  it('allows when no policy for service', () => {
+    const config: PolicyConfig = {};
+    const result = matchPolicy('anthropic', 'POST', '/v1/messages', config);
+    expect(result.allowed).toBe(true);
+    expect(result.matchedRule).toBeUndefined();
+  });
+
+  it('allows when defaultAction is allow and no matching rule', () => {
+    const config: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+      }
+    };
+    const result = matchPolicy('anthropic', 'POST', '/v1/messages', config);
+    expect(result.allowed).toBe(true);
+    expect(result.matchedRule).toBeUndefined();
+  });
+
+  it('denies when defaultAction is deny and no matching rule', () => {
+    const config: PolicyConfig = {
+      gmail: {
+        defaultAction: 'deny',
+        rules: [{ method: 'POST', path: '/v1/users/*/drafts', action: 'allow' }]
+      }
+    };
+    const result = matchPolicy('gmail', 'GET', '/v1/users/me/labels', config);
+    expect(result.allowed).toBe(false);
+    expect(result.matchedRule).toBeUndefined();
+  });
+
+  it('matches exact method and path', () => {
+    const config: PolicyConfig = {
+      gmail: {
+        defaultAction: 'allow',
+        rules: [{ method: 'POST', path: '/v1/users/*/messages/send', action: 'deny' }]
+      }
+    };
+    const result = matchPolicy('gmail', 'POST', '/v1/users/me/messages/send', config);
+    expect(result.allowed).toBe(false);
+    expect(result.matchedRule).toEqual({ method: 'POST', path: '/v1/users/*/messages/send', action: 'deny' });
+  });
+
+  it('wildcard method * matches any method', () => {
+    const config: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+      }
+    };
+    expect(matchPolicy('anthropic', 'GET', '/v1/organizations/org123/members', config).allowed).toBe(false);
+    expect(matchPolicy('anthropic', 'POST', '/v1/organizations/org123/api-keys', config).allowed).toBe(false);
+    expect(matchPolicy('anthropic', 'DELETE', '/v1/organizations/org123', config).allowed).toBe(false);
+  });
+
+  it('case-insensitive method matching', () => {
+    const config: PolicyConfig = {
+      openai: {
+        defaultAction: 'allow',
+        rules: [{ method: 'DELETE', path: '/v1/**', action: 'deny' }]
+      }
+    };
+    expect(matchPolicy('openai', 'delete', '/v1/files/file-abc', config).allowed).toBe(false);
+    expect(matchPolicy('openai', 'Delete', '/v1/files/file-abc', config).allowed).toBe(false);
+  });
+
+  it('first-match-wins ordering', () => {
+    const config: PolicyConfig = {
+      test: {
+        defaultAction: 'deny',
+        rules: [
+          { method: 'POST', path: '/v1/safe', action: 'allow' },
+          { method: '*', path: '/v1/**', action: 'deny' },
+        ]
+      }
+    };
+    // POST /v1/safe hits the first rule (allow)
+    expect(matchPolicy('test', 'POST', '/v1/safe', config).allowed).toBe(true);
+    // GET /v1/safe hits the second rule (deny) since method doesn't match first
+    expect(matchPolicy('test', 'GET', '/v1/safe', config).allowed).toBe(false);
+  });
+
+  it('substring wildcard in segment (Slack admin.*)', () => {
+    const config: PolicyConfig = {
+      slack: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/admin.*', action: 'deny' }]
+      }
+    };
+    expect(matchPolicy('slack', 'POST', '/admin.users.list', config).allowed).toBe(false);
+    expect(matchPolicy('slack', 'POST', '/chat.postMessage', config).allowed).toBe(true);
+  });
+});
+
+describe('validatePolicyConfig', () => {
+  it('valid config passes', () => {
+    const config: PolicyConfig = {
+      anthropic: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+      }
+    };
+    const result = validatePolicyConfig(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('invalid action is reported', () => {
+    const config = {
+      gmail: {
+        defaultAction: 'allow' as const,
+        rules: [{ method: 'POST', path: '/v1/send', action: 'block' as any }]
+      }
+    };
+    const result = validatePolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('unknown action "block"');
+  });
+
+  it('invalid defaultAction is reported', () => {
+    const config = {
+      test: {
+        defaultAction: 'reject' as any,
+        rules: []
+      }
+    };
+    const result = validatePolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('invalid defaultAction "reject"');
+  });
+
+  it('path not starting with / is reported', () => {
+    const config: PolicyConfig = {
+      test: {
+        defaultAction: 'allow',
+        rules: [{ method: '*', path: 'v1/messages', action: 'deny' }]
+      }
+    };
+    const result = validatePolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain("doesn't start with /");
+  });
+
+  it('empty config is valid', () => {
+    const result = validatePolicyConfig({});
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('loadPolicyFromConfig', () => {
+  it('returns empty config when no policy', () => {
+    const result = loadPolicyFromConfig({});
+    expect(result).toEqual({});
+  });
+
+  it('parses policy section correctly', () => {
+    const config = {
+      policy: {
+        anthropic: {
+          defaultAction: 'allow',
+          rules: [{ method: '*', path: '/v1/organizations/**', action: 'deny' }]
+        }
+      }
+    };
+    const result = loadPolicyFromConfig(config);
+    expect(result.anthropic).toBeDefined();
+    expect(result.anthropic.defaultAction).toBe('allow');
+    expect(result.anthropic.rules).toHaveLength(1);
+    expect(result.anthropic.rules[0].action).toBe('deny');
+  });
+
+  it('defaults to allow for unknown defaultAction', () => {
+    const config = {
+      policy: {
+        test: { defaultAction: 'whatever', rules: [] }
+      }
+    };
+    const result = loadPolicyFromConfig(config);
+    expect(result.test.defaultAction).toBe('allow');
+  });
+});
+
+describe('getDefaultPolicyPresets', () => {
+  it('returns presets for expected services', () => {
+    const presets = getDefaultPolicyPresets();
+    expect(presets.anthropic).toBeDefined();
+    expect(presets.openai).toBeDefined();
+    expect(presets.gmail).toBeDefined();
+    expect(presets.slack).toBeDefined();
+  });
+
+  it('anthropic preset denies admin API', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('anthropic', 'GET', '/v1/organizations/org123/members', presets);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('anthropic preset allows inference', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('anthropic', 'POST', '/v1/messages', presets);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('openai preset denies admin API', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('openai', 'GET', '/v1/organization/users', presets);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('openai preset denies DELETE', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('openai', 'DELETE', '/v1/files/file-abc', presets);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('openai preset allows inference', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('openai', 'POST', '/v1/chat/completions', presets);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('slack preset denies admin methods', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('slack', 'POST', '/admin.users.list', presets);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('slack preset allows normal methods', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('slack', 'POST', '/chat.postMessage', presets);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('gmail preset denies send', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('gmail', 'POST', '/v1/users/me/messages/send', presets);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('gmail preset allows drafts', () => {
+    const presets = getDefaultPolicyPresets();
+    const result = matchPolicy('gmail', 'POST', '/v1/users/me/drafts', presets);
+    expect(result.allowed).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds request-level policy enforcement — the proxy now evaluates method + path rules *before* touching credentials, so denied requests never get real auth headers. Also includes CLI tools to inspect/test policies and fixes for 4 HIGH-severity findings from a pre-release security audit.

  ## Request Policies

  Per-service rules that block dangerous API endpoints before credentials are injected. A prompt-injected agent can't delete your OpenAI files or call Slack admin methods — the proxy returns 403 and never decrypts
  the key.

  - **Segment-based path matching** — `*` matches within a segment, `**` matches zero or more segments
  - **First-match-wins** evaluation with configurable `defaultAction` per service
  - **Built-in presets** for Anthropic (deny admin API), OpenAI (deny admin + DELETE), Gmail (deny send), Slack (deny admin methods)
  - **`aquaman setup`** applies safe presets automatically for stored services
  - **`aquaman doctor`** validates policy config and shows per-service deny rule summaries
  - **No policy = allow all** — fully backward compatible

  ```yaml
  # ~/.aquaman/config.yaml
  policy:
    anthropic:
      defaultAction: allow
      rules:
        - method: "*"
          path: "/v1/organizations/**"
          action: deny
```
  Policy CLI

  - aquaman policy list — display all configured rules per service
  - aquaman policy test <service> <method> <path> — dry-run a request and see ALLOWED/DENIED with matching rule

  DX Improvements

  - aquaman status now shows policy summary (service count, rule count, per-service breakdown)
  - aquaman doctor shows compact deny rule details when policy is valid
  - aquaman setup displays actual rules being applied instead of generic "inference only" text
  - aquaman audit tail shows error detail on FAIL entries (FAIL: <reason> instead of just FAIL)

  Security Fixes

  - Credential name validation (H1/H2) — credentials add/delete reject path traversal and shell metacharacters (../../evil, A;rm -rf). Defense-in-depth validation added to Vault backend's getPath().
  - Shell RC injection (H3) — env-writer validates service names against SAFE_SERVICE_NAME before writing export statements to .bashrc/.zshrc
  - OAuth SSRF prevention (H4) — token URL hostname validated after {template} variable resolution to prevent credential exfiltration via poisoned store values