### PR TITLE
v0.11.0 — OpenClaw 2026.4.9 Compatibility + ClawHub Ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,12 @@ jobs:
           fail_ci_if_error: true
 
   e2e-openclaw:
-    name: E2E OpenClaw Plugin
+    name: E2E OpenClaw Plugin (${{ matrix.openclaw-version }})
     runs-on: ubuntu-latest
     continue-on-error: true
+    strategy:
+      matrix:
+        openclaw-version: ['2026.4.7', '2026.4.9']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -115,10 +118,10 @@ jobs:
           path: |
             /usr/local/lib/node_modules/openclaw
             /usr/local/bin/openclaw
-          key: openclaw-${{ runner.os }}-node24-2026.3.8
+          key: openclaw-${{ runner.os }}-node24-${{ matrix.openclaw-version }}
       - name: Install openclaw
         if: steps.cache-openclaw.outputs.cache-hit != 'true'
-        run: npm install -g openclaw@2026.3.8
+        run: npm install -g openclaw@${{ matrix.openclaw-version }}
       - run: npx vitest run test/e2e/openclaw-plugin.test.ts
 
       - name: Install plugin for security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,9 @@ jobs:
           fail_ci_if_error: true
 
   e2e-openclaw:
-    name: E2E OpenClaw Plugin (${{ matrix.openclaw-version }})
+    name: E2E OpenClaw Plugin
     runs-on: ubuntu-latest
     continue-on-error: true
-    strategy:
-      matrix:
-        openclaw-version: ['2026.4.7', '2026.4.9']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -118,10 +115,10 @@ jobs:
           path: |
             /usr/local/lib/node_modules/openclaw
             /usr/local/bin/openclaw
-          key: openclaw-${{ runner.os }}-node24-${{ matrix.openclaw-version }}
+          key: openclaw-${{ runner.os }}-node24-2026.4.9
       - name: Install openclaw
         if: steps.cache-openclaw.outputs.cache-hit != 'true'
-        run: npm install -g openclaw@${{ matrix.openclaw-version }}
+        run: npm install -g openclaw@2026.4.9
       - run: npx vitest run test/e2e/openclaw-plugin.test.ts
 
       - name: Install plugin for security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,14 @@ jobs:
           cp packages/plugin/package.json ~/.openclaw/extensions/aquaman-plugin/
           cp packages/plugin/openclaw.plugin.json ~/.openclaw/extensions/aquaman-plugin/
           cp -r packages/plugin/src ~/.openclaw/extensions/aquaman-plugin/src
-          cd ~/.openclaw/extensions/aquaman-plugin && npm install --omit=dev --silent
+
+          # Link local proxy build (aquaman-proxy@0.11.0 isn't published yet)
+          mkdir -p ~/.openclaw/extensions/aquaman-plugin/node_modules/.bin
+          ln -sf $(pwd)/packages/proxy ~/.openclaw/extensions/aquaman-plugin/node_modules/aquaman-proxy
+          ln -sf $(pwd)/node_modules/.bin/aquaman ~/.openclaw/extensions/aquaman-plugin/node_modules/.bin/aquaman
+
+          # Install remaining deps (undici etc.)
+          cd ~/.openclaw/extensions/aquaman-plugin && npm install --omit=dev --silent --legacy-peer-deps
 
           # Write openclaw.json with plugin allowlist (but no tools.profile —
           # that's the operator's choice, not ours to impose)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Credential isolation for **OpenClaw Gateway**. API keys and channel tokens never
 
 **Target platform:** OpenClaw Gateway on Unix-like systems (Linux, macOS, WSL2). The Gateway is OpenClaw's core server component—a Node.js/TypeScript service that runs as a systemd user service (Linux/WSL2) or LaunchAgent (macOS).
 
-**Published on npm** as `aquaman-plugin` and `aquaman-proxy`. Install via `openclaw plugins install aquaman-plugin`.
+**Published on npm** as `aquaman-plugin` and `aquaman-proxy`. Install via `openclaw plugins install aquaman-plugin`. Also publishable to ClawHub (OpenClaw's native plugin registry, default since 2026.3.22) for native discoverability.
 
 ## Architecture Decision: Isolation vs Detection
 
@@ -52,7 +52,7 @@ The plugin (`packages/plugin/`) integrates with the OpenClaw Gateway's plugin SD
 8. Registers `/aquaman-status` command (human-facing), `aquaman_status` tool (agent-facing), and `/aquaman` CLI commands
 
 **Key files:**
-- `index.ts` - Plugin entry point with `OpenClawPluginDefinition` object export (`export default plugin`) — this is the actual running code OpenClaw loads. Does NOT import `child_process` or `fetch` directly (separated to avoid OpenClaw security scanner false positives).
+- `index.ts` - Plugin entry point with `OpenClawPluginDefinition` object export (`export default plugin`) — this is the actual running code OpenClaw loads. Does NOT import `child_process` or `fetch` directly (separated to avoid OpenClaw security scanner false positives). SDK types (`OpenClawPluginApi`, `OpenClawPluginDefinition`) are defined locally to avoid `openclaw/plugin-sdk` import resolution failures on OpenClaw 2026.3.23+ (see #53403).
 - `src/proxy-manager.ts` - Spawns/manages the proxy child process (contains `child_process` import)
 - `src/proxy-health.ts` - Proxy health check and host map fetching (contains `fetch` calls)
 - `src/plugin.ts` - Class-based plugin implementation (alternative architecture, used by standalone tests)
@@ -118,7 +118,7 @@ OpenClaw 2026.2.15+ also reports an environment-level advisory:
 
 There is no suppression mechanism for code findings (no inline annotations, no `.auditignore`). The only fix is to ensure trigger patterns don't co-exist in the same file.
 
-**Current state (v0.9.2, tested through 2026.3.8):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The `request-policy.ts` file contains no `child_process`, `process.env`, or `fetch` — zero scanner risk. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9). Note: OpenClaw 2026.3.x fresh installs default `tools.profile` to `messaging` — `aquaman_status` tool may not surface unless the operator configures `tools.profile` to include it.
+**Current state (v0.11.0, tested through 2026.4.9):** 2 expected findings: `dangerous-exec` on `proxy-manager.ts` (true positive — it spawns the proxy process), `tools_reachable_permissive_policy` (environment advisory — not a code issue). 0 env-harvesting findings. The `request-policy.ts` file contains no `child_process`, `process.env`, or `fetch` — zero scanner risk. The scanner recursively scans `src/` and `dist/` subdirectories (since 2026.2.9). Note: OpenClaw 2026.3.x+ fresh installs default `tools.profile` to `messaging` — `aquaman_status` tool may not surface unless the operator configures `tools.profile` to include it.
 
 **Mitigations:**
 - `aquaman setup` auto-sets `plugins.allow: ["aquaman-plugin"]` in `openclaw.json` (resolves the `extensions_no_allowlist` audit finding)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ The plugin (`packages/plugin/`) integrates with the OpenClaw Gateway's plugin SD
 8. Registers `/aquaman-status` command (human-facing), `aquaman_status` tool (agent-facing), and `/aquaman` CLI commands
 
 **Key files:**
-- `index.ts` - Plugin entry point with `OpenClawPluginDefinition` object export (`export default plugin`) — this is the actual running code OpenClaw loads. Does NOT import `child_process` or `fetch` directly (separated to avoid OpenClaw security scanner false positives). SDK types (`OpenClawPluginApi`, `OpenClawPluginDefinition`) are defined locally to avoid `openclaw/plugin-sdk` import resolution failures on OpenClaw 2026.3.23+ (see #53403).
+- `index.ts` - Plugin entry point with `OpenClawPluginDefinition` object export (`export default plugin`) — this is the actual running code OpenClaw loads. Does NOT import `child_process` or `fetch` directly (separated to avoid OpenClaw security scanner false positives). SDK types (`OpenClawPluginApi`, `OpenClawPluginDefinition`) are defined locally to avoid `openclaw/plugin-sdk` import resolution failures on OpenClaw 2026.3.23+ (see #53403). Registers commands/tools in ALL modes (even without proxy binary) for graceful degradation. CLI commands delegate to `execAquamanProxyCli()` / `execAquamanProxyInteractive()` from `proxy-manager.ts`.
 - `src/proxy-manager.ts` - Spawns/manages the proxy child process (contains `child_process` import)
 - `src/proxy-health.ts` - Proxy health check and host map fetching (contains `fetch` calls)
 - `src/plugin.ts` - Class-based plugin implementation (alternative architecture, used by standalone tests)
@@ -357,6 +357,7 @@ EOF
 cat > ~/.openclaw/openclaw.json << 'EOF'
 {
   "plugins": {
+    "allow": ["aquaman-plugin"],
     "entries": {
       "aquaman-plugin": {
         "enabled": true,
@@ -378,7 +379,7 @@ openclaw agent --local --message "hello" --session-id test --json 2>&1 | head -8
 
 ```
 [plugins] Aquaman plugin loaded
-[plugins] aquaman CLI found, will start proxy on gateway start
+[plugins] aquaman proxy found, will start proxy on gateway start
 [plugins] Set ANTHROPIC_BASE_URL=http://aquaman.local/anthropic
 [plugins] Set OPENAI_BASE_URL=http://aquaman.local/openai
 [plugins] Aquaman plugin registered successfully
@@ -393,24 +394,81 @@ openclaw agent --local --message "hello" --session-id test --json 2>&1 | head -8
 ### Automated tests:
 
 ```bash
-npm run test:e2e                # All e2e tests (17 files)
+npm run test:e2e                # All e2e tests (18 files)
 npm run test:unit               # All unit tests (18 files)
-npm test                        # Everything (~548 tests, 35 files)
+npm test                        # Everything (~555 tests, 36 files)
 ```
 
-### Quick proxy-only smoke test:
+### Quick proxy smoke test (credential injection + policy + health):
 
 ```bash
-# Start proxy
-npx tsx packages/proxy/src/cli/index.ts daemon &
+# 1. Store dummy test credential
+node -e "
+const kt = require('./node_modules/keytar');
+const k = kt.default || kt;
+k.setPassword('aquaman/anthropic', 'api_key', 'sk-ant-smoketest-key').then(() => console.log('stored'));
+"
 
-# Curl through it via UDS (expect 401 with dummy key = proxy injected it)
+# 2. Start proxy
+npx tsx packages/proxy/src/cli/index.ts daemon &
+sleep 2
+
+# 3. Credential injection (expect 401 from Anthropic = proxy injected the dummy key)
 curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/messages \
   -H "Content-Type: application/json" \
   -d '{"model":"claude-sonnet-4-20250514","max_tokens":5,"messages":[{"role":"user","content":"hi"}]}'
+# Expect: {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}
 
-# Stop
+# 4. Health endpoint
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/_health
+# Expect: {"status":"ok","version":"0.11.0",...}
+
+# 5. Policy enforcement (expect 403 — admin API blocked by default policy)
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/anthropic/v1/organizations/org123/members
+# Expect: {"error":"Request denied by policy: GET /anthropic/v1/organizations/org123/members","fix":"..."}
+
+# 6. Unknown service (expect 404)
+curl -s --unix-socket ~/.aquaman/proxy.sock http://localhost/unknown-service/test
+# Expect: Not found
+
+# 7. Stop proxy and clean up
 npx tsx packages/proxy/src/cli/index.ts stop
+node -e "
+const kt = require('./node_modules/keytar');
+const k = kt.default || kt;
+k.deletePassword('aquaman/anthropic', 'api_key').then(() => console.log('cleaned up'));
+"
+```
+
+### Quick plugin CLI smoke test (via bundled proxy binary):
+
+```bash
+# After installing plugin to ~/.openclaw/extensions/aquaman-plugin/ (see above):
+openclaw aquaman status          # Shows proxy status + binary found
+openclaw aquaman doctor          # Runs diagnostic checks
+openclaw aquaman credentials list # Lists stored credentials
+openclaw aquaman policy-list     # Shows request policy rules
+openclaw aquaman audit-tail      # Shows recent audit entries
+openclaw aquaman services-list   # Lists configured services
+```
+
+### Plugin degraded mode smoke test (ClawHub install without setup):
+
+```bash
+# Temporarily hide the aquaman binary to simulate missing proxy
+mv ~/.openclaw/extensions/aquaman-plugin/node_modules/.bin/aquaman /tmp/aquaman-hidden
+# Also remove from PATH if globally installed
+
+# Start OpenClaw — plugin should:
+# - Log "aquaman proxy not found" warning
+# - NOT set ANTHROPIC_BASE_URL (no sentinel env vars)
+# - Still register /aquaman-status command
+# - Still register aquaman_status tool
+openclaw plugins list 2>&1 | grep -E "aquaman|BASE_URL"
+# Expect: "aquaman proxy not found", NO "ANTHROPIC_BASE_URL" lines
+
+# Restore
+mv /tmp/aquaman-hidden ~/.openclaw/extensions/aquaman-plugin/node_modules/.bin/aquaman
 ```
 
 ## Manual Testing

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Credential isolation for OpenClaw — secrets stay submerged, agents stay dry.
+API key protection for OpenClaw — secrets stay submerged, agents stay dry.
 
 You bought a brand new Mac Mini, set up OpenClaw, and now you're staring at your `~/.openclaw/openclaw.json` wondering why your Anthropic API key is sitting there in plaintext. You read the articles. You know what happens when an agent gets prompt-injected. We get it.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ aquaman setup                             # stores keys, installs OpenClaw plugi
 openclaw                                  # proxy starts automatically via plugin
 ```
 
+> **We recommend `aquaman setup`** — it does more than just install the plugin: it stores credentials,
+> configures your backend, writes `openclaw.json`, and generates auth profiles. If you prefer to install
+> the plugin directly: `openclaw plugins install aquaman-plugin` (on OpenClaw 2026.3.22+, this checks
+> [ClawHub](https://clawhub.ai) first, then falls back to npm).
+
 > `aquaman setup` auto-detects your credential backend. macOS defaults to Keychain,
 > Linux defaults to encrypted file. Override with `--backend`:
 > `aquaman setup --backend keepassxc`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-API key protection for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞
+API key protection for OpenClaw — credentials stay in your vault, never in the agent's memory. 🔱🦞
 
 You bought a brand new Mac Mini, set up OpenClaw, and now you're staring at your `~/.openclaw/openclaw.json` wondering why your Anthropic API key is sitting there in plaintext. You read the articles. You know what happens when an agent gets prompt-injected. We get it.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-API key protection for OpenClaw — secrets stay submerged, agents stay dry.
+API key protection for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞
 
 You bought a brand new Mac Mini, set up OpenClaw, and now you're staring at your `~/.openclaw/openclaw.json` wondering why your Anthropic API key is sitting there in plaintext. You read the articles. You know what happens when an agent gets prompt-injected. We get it.
 
@@ -22,50 +22,27 @@ No SDK changes required. The proxy is transparent — your agent talks to `aquam
 
 ## Quick Start
 
-### Local (macOS / Linux)
-
 ```bash
-npm install -g aquaman-proxy              # install the proxy CLI
-aquaman setup                             # stores keys, installs OpenClaw plugin
-openclaw                                  # proxy starts automatically via plugin
+openclaw plugins install aquaman-plugin   # 1. install plugin + proxy
+openclaw aquaman setup                    # 2. store your API keys
+openclaw                                  # 3. done — proxy starts automatically
 ```
 
-> **We recommend `aquaman setup`** — it does more than just install the plugin: it stores credentials,
-> configures your backend, writes `openclaw.json`, and generates auth profiles. If you prefer to install
-> the plugin directly: `openclaw plugins install aquaman-plugin` (on OpenClaw 2026.3.22+, this checks
-> [ClawHub](https://clawhub.ai) first, then falls back to npm).
+Troubleshooting: `openclaw aquaman doctor`
 
-> `aquaman setup` auto-detects your credential backend. macOS defaults to Keychain,
-> Linux defaults to encrypted file. Override with `--backend`:
-> `aquaman setup --backend keepassxc`
-> Options: `keychain`, `encrypted-file`, `keepassxc`, `1password`, `vault`, `systemd-creds`, `bitwarden`
+> **Using npm?** `npm install -g aquaman-proxy && aquaman setup` does
+> the same thing — installs the proxy CLI, stores your keys, and installs
+> the plugin. Use this if you prefer managing packages with npm.
 
-Existing plaintext credentials are migrated automatically during setup.
-The migration detects credentials from channels (Telegram, Slack, etc.)
-**and** third-party plugins/skills (any `*token*`, `*key*`, `*secret*`,
-`*password*` fields in `openclaw.json` plugin configs). Upstream URLs are
-auto-detected from plugin config fields like `endpoint` or `baseUrl`.
-Run again anytime to migrate new credentials: `aquaman migrate openclaw --auto`
+### Docker
 
-The plugin starts the proxy for you — no extra steps. To check
-everything is wired up correctly:
-
-```bash
-aquaman doctor                 # diagnose issues with actionable fixes
-aquaman help                   # list all commands
-```
-
-### Docker Setup
-
-Single-image deployment — same UDS architecture as local, containerized.
+Single-image deployment — same UDS architecture, containerized.
 
 ```bash
 git clone https://github.com/tech4242/aquaman.git && cd aquaman
 cp docker/.env.example docker/.env
-# Edit docker/.env — pick a backend and set its credentials
-# needless to say instead of .env you should handle your env properly but this is a starting point you can test.
-npm run docker:build
-npm run docker:run
+# Edit docker/.env — pick a backend and set credentials
+npm run docker:build && npm run docker:run
 ```
 
 ## How It Works

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/openclaw:latest
 
 # Install aquaman proxy (includes credential stores, audit, CLI)
-RUN npm install -g aquaman-proxy@0.10.0
+RUN npm install -g aquaman-proxy@0.11.0
 
 # Install plugin into OpenClaw extensions
 RUN mkdir -p /home/node/.openclaw/extensions/aquaman-plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Credential isolation proxy for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞",
   "type": "module",
@@ -42,7 +42,7 @@
     "@types/ws": "^8.5.10",
     "@vitest/coverage-v8": "^1.2.0",
     "ajv": "^8.17.0",
-    "openclaw": "^2026.3.8",
+    "openclaw": "^2026.4.9",
     "oxlint": "^0.2.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aquaman",
   "version": "0.11.0",
   "private": true,
-  "description": "Credential isolation proxy for OpenClaw — secrets stay submerged, agents stay dry. 🔱🦞",
+  "description": "API key protection for OpenClaw — credentials stay in your vault, never in the agent's memory",
   "type": "module",
   "workspaces": [
     "packages/*"
@@ -26,14 +26,18 @@
     "docker:run": "docker run --rm -it aquaman"
   },
   "keywords": [
+    "aquaman",
     "openclaw",
     "security",
-    "audit",
     "credentials",
-    "ai-agent",
-    "keychain",
     "vault",
-    "1password"
+    "1password",
+    "api-key",
+    "secrets",
+    "keychain",
+    "bitwarden",
+    "ai-agent",
+    "api-protection"
   ],
   "author": "tech4242",
   "license": "MIT",

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,6 +1,8 @@
-# aquaman-plugin
+# Aquaman — API Key Protection for OpenClaw
 
-OpenClaw Gateway plugin for [aquaman](https://github.com/tech4242/aquaman) — credential isolation for OpenClaw.
+Your API keys and tokens stay in your vault. The agent never sees them.
+Even a compromised agent can't steal credentials — they live in a
+separate process.
 
 ```
 Agent / OpenClaw Gateway              Aquaman Proxy
@@ -29,28 +31,57 @@ Agent / OpenClaw Gateway              Aquaman Proxy
                                slack.com/api  ...
 ```
 
-This plugin is the left side — it runs inside the Gateway process and routes all LLM and channel API traffic through the aquaman proxy via Unix domain socket. Credentials never enter the agent's address space.
+## What It Does
 
-**What it does on load:**
-1. Sets `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` to `http://aquaman.local/<service>` (routed to UDS)
-2. Spawns the proxy daemon via `ProxyManager`
-3. Activates a `globalThis.fetch` interceptor to redirect channel API traffic through the proxy
-4. Registers `/aquaman-status` command and `aquaman_status` tool
+1. **Secrets stay in your vault** — Keychain, 1Password, HashiCorp Vault, KeePassXC, systemd-creds, Bitwarden, or encrypted file
+2. **Agent gets a proxy URL** — requests route through a local proxy that injects auth headers on the fly
+3. **Dangerous endpoints blocked** — request policies deny admin APIs, prevent deletions, block sends — before credentials are even injected
+4. **Tamper-evident audit log** — every credential use logged with SHA-256 hash chains
 
-## Quick Start
+## Install
+
+### Installed from ClawHub or `openclaw plugins install`?
+
+The plugin and proxy are installed together. Now run setup to store your keys:
+
+```bash
+openclaw aquaman setup
+```
+
+Or in your terminal:
+
+```bash
+aquaman setup
+```
+
+### Fresh install (recommended for developers)
 
 ```bash
 npm install -g aquaman-proxy
-aquaman setup                   # stores keys, installs this plugin, applies policy defaults
-openclaw                        # proxy starts automatically
+aquaman setup
+openclaw
 ```
 
-> **We recommend `aquaman setup`** — it does more than just install the plugin: it stores credentials,
-> configures your backend, writes `openclaw.json`, and generates auth profiles. If you prefer to install
-> the plugin directly: `openclaw plugins install aquaman-plugin` (on OpenClaw 2026.3.22+, this checks
-> [ClawHub](https://clawhub.ai) first, then falls back to npm).
+`aquaman setup` does everything: stores your API keys, picks the right vault backend for your OS, installs this plugin, and applies safe request policy defaults.
 
-Troubleshooting: `aquaman doctor`
+## Available Commands
+
+All commands work via OpenClaw CLI or your terminal:
+
+| OpenClaw CLI | Terminal | Description |
+|---|---|---|
+| `openclaw aquaman setup` | `aquaman setup` | Onboarding wizard — stores keys, configures backend |
+| `openclaw aquaman doctor` | `aquaman doctor` | Diagnostic checks with actionable fixes |
+| `openclaw aquaman credentials list` | `aquaman credentials list` | List stored credentials |
+| `openclaw aquaman credentials add` | `aquaman credentials add` | Add a credential (interactive) |
+| `openclaw aquaman policy-list` | `aquaman policy list` | Show request policy rules |
+| `openclaw aquaman audit-tail` | `aquaman audit tail` | Recent audit entries |
+| `openclaw aquaman services-list` | `aquaman services list` | List configured services |
+| `openclaw aquaman status` | `aquaman status` | Proxy status |
+
+Slash commands in chat: `/aquaman-status`, `/aquaman list`, `/aquaman doctor`
+
+Troubleshooting: `openclaw aquaman doctor` or `aquaman doctor`
 
 ## Config Options
 
@@ -74,7 +105,7 @@ Troubleshooting: `aquaman doctor`
 
 ## Documentation
 
-See the [main README](https://github.com/tech4242/aquaman#readme) for the full security model, architecture diagrams, and manual testing guides.
+See the [main README](https://github.com/tech4242/aquaman#readme) for the full security model, architecture diagrams, request policy config, and manual testing guides.
 
 ## License
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -45,6 +45,11 @@ aquaman setup                   # stores keys, installs this plugin, applies pol
 openclaw                        # proxy starts automatically
 ```
 
+> **We recommend `aquaman setup`** — it does more than just install the plugin: it stores credentials,
+> configures your backend, writes `openclaw.json`, and generates auth profiles. If you prefer to install
+> the plugin directly: `openclaw plugins install aquaman-plugin` (on OpenClaw 2026.3.22+, this checks
+> [ClawHub](https://clawhub.ai) first, then falls back to npm).
+
 Troubleshooting: `aquaman doctor`
 
 ## Config Options

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -38,31 +38,16 @@ Agent / OpenClaw Gateway              Aquaman Proxy
 3. **Dangerous endpoints blocked** — request policies deny admin APIs, prevent deletions, block sends — before credentials are even injected
 4. **Tamper-evident audit log** — every credential use logged with SHA-256 hash chains
 
-## Install
-
-### Installed from ClawHub or `openclaw plugins install`?
-
-The plugin and proxy are installed together. Now run setup to store your keys:
+## Quick Start
 
 ```bash
-openclaw aquaman setup
+openclaw plugins install aquaman-plugin   # 1. install plugin + proxy
+openclaw aquaman setup                    # 2. store your API keys
+openclaw                                  # 3. done — proxy starts automatically
 ```
 
-Or in your terminal:
-
-```bash
-aquaman setup
-```
-
-### Fresh install (recommended for developers)
-
-```bash
-npm install -g aquaman-proxy
-aquaman setup
-openclaw
-```
-
-`aquaman setup` does everything: stores your API keys, picks the right vault backend for your OS, installs this plugin, and applies safe request policy defaults.
+> **Using npm?** `npm install -g aquaman-proxy && aquaman setup` does
+> the same thing. Use this if you prefer managing packages with npm.
 
 ## Available Commands
 

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -16,10 +16,53 @@
  *   - Agent never sees the actual API keys
  */
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+// OpenClaw plugin SDK types — defined locally to avoid import resolution failures.
+// The root import "openclaw/plugin-sdk" broke for user-installed plugins in OpenClaw 2026.3.23
+// (GitHub issue #53403: jiti resolver can't walk from ~/.openclaw/extensions/ to OpenClaw's
+// package tree). Since we only use these as compile-time types, local definitions are zero-risk
+// and make the plugin resilient to SDK path changes. Revert to SDK import if OpenClaw stabilizes
+// module resolution for user-installed plugins.
 
-// OpenClawPluginDefinition exists in the SDK internals but isn't re-exported from "openclaw/plugin-sdk".
-// Mirror the type here until OpenClaw exposes it from the barrel.
+interface OpenClawPluginLogger {
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+interface OpenClawPluginApi {
+  logger: OpenClawPluginLogger;
+  pluginConfig: unknown;
+  registerService(def: {
+    id: string;
+    start(ctx: { logger: OpenClawPluginLogger }): void | Promise<void>;
+    stop(ctx: { logger: OpenClawPluginLogger }): void | Promise<void>;
+  }): void;
+  registerCommand(def: {
+    name: string;
+    description: string;
+    acceptsArgs: boolean;
+    requireAuth: boolean;
+    handler(): Promise<{ text: string }>;
+  }): void;
+  registerCli?(
+    fn: (opts: { program: any }) => void,
+    opts: { commands: string[] },
+  ): void;
+  registerTool(
+    factory: () => {
+      name: string;
+      label: string;
+      description: string;
+      parameters: { type: "object"; properties: Record<string, unknown>; required: string[] };
+      execute(toolCallId: string, params: unknown): Promise<{
+        content: { type: "text"; text: string }[];
+        details: unknown;
+      }>;
+    },
+    opts: { names: string[] },
+  ): void;
+}
+
 type OpenClawPluginDefinition = {
   id?: string;
   name?: string;

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -74,7 +74,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { HttpInterceptor, createHttpInterceptor } from "./src/http-interceptor.js";
-import { createProxyManager, type ProxyManager } from "./src/proxy-manager.js";
+import { createProxyManager, findAquamanProxyBinary, execAquamanProxyCli, execAquamanProxyInteractive, type ProxyManager } from "./src/proxy-manager.js";
 import { loadHostMap, isProxyRunning, getProxyVersion } from "./src/proxy-health.js";
 
 /**
@@ -145,10 +145,10 @@ const FALLBACK_HOST_MAP = new Map<string, string>([
 ]);
 
 /**
- * Check if aquaman CLI is installed (fs-based, no shell execution)
+ * Check if aquaman proxy binary is available (local node_modules or PATH)
  */
-function isAquamanInstalled(): boolean {
-  return findInPath("aquaman") !== null;
+function isAquamanProxyInstalled(): boolean {
+  return findAquamanProxyBinary() !== null;
 }
 
 /**
@@ -248,7 +248,34 @@ function configureEnvironment(log: OpenClawPluginApi["logger"], services: string
 }
 
 /**
- * Register the aquaman_status tool
+ * Build status object for both the tool and slash command
+ */
+function getStatus(services: string[]) {
+  const cliInstalled = isAquamanProxyInstalled();
+  return {
+    cliInstalled,
+    proxyRunning: proxyManager !== null,
+    socketPath: socketPath || getDefaultSocketPath(),
+    services,
+    httpInterceptorActive: httpInterceptor?.isActive() ?? false,
+    ...(cliInstalled ? {} : { fix: "Run: npm install -g aquaman-proxy && aquaman setup" }),
+    ...(!cliInstalled ? {} : proxyManager === null ? { fix: "Run: aquaman setup (or: openclaw aquaman setup)" } : {}),
+    environmentVariables: Object.fromEntries(
+      services.map((s) => {
+        const key =
+          s === "anthropic"
+            ? "ANTHROPIC_BASE_URL"
+            : s === "openai"
+              ? "OPENAI_BASE_URL"
+              : `${s.toUpperCase()}_BASE_URL`;
+        return [key, process.env[key] ?? null];
+      })
+    ),
+  };
+}
+
+/**
+ * Register the aquaman_status tool — always registered (works in degraded mode)
  */
 function registerStatusTool(api: OpenClawPluginApi, services: string[]): void {
   api.registerTool(
@@ -264,23 +291,7 @@ function registerStatusTool(api: OpenClawPluginApi, services: string[]): void {
           required: [] as string[],
         },
         async execute(_toolCallId: string, _params: unknown) {
-          const status = {
-            proxyRunning: proxyManager !== null,
-            socketPath: socketPath || getDefaultSocketPath(),
-            services,
-            httpInterceptorActive: httpInterceptor?.isActive() ?? false,
-            environmentVariables: Object.fromEntries(
-              services.map((s) => {
-                const key =
-                  s === "anthropic"
-                    ? "ANTHROPIC_BASE_URL"
-                    : s === "openai"
-                      ? "OPENAI_BASE_URL"
-                      : `${s.toUpperCase()}_BASE_URL`;
-                return [key, process.env[key] ?? null];
-              })
-            ),
-          };
+          const status = getStatus(services);
           return {
             content: [{ type: "text" as const, text: JSON.stringify(status, null, 2) }],
             details: status,
@@ -342,9 +353,9 @@ function ensureAuthProfiles(log: OpenClawPluginApi["logger"], services: string[]
  */
 const plugin: OpenClawPluginDefinition = {
   id: 'aquaman-plugin',
-  name: 'Aquaman Vault',
+  name: 'Aquaman — API Key Protection',
   version: PLUGIN_VERSION,
-  description: 'Credential isolation for OpenClaw — API keys never enter the agent process',
+  description: 'API key protection for OpenClaw — credentials stay in your vault, never in the agent\'s memory',
 
   register(api) {
     api.logger.info("Aquaman plugin loaded");
@@ -356,70 +367,76 @@ const plugin: OpenClawPluginDefinition = {
     // Auto-generate auth-profiles.json if missing
     ensureAuthProfiles(api.logger, configuredServices);
 
-    // Local proxy mode — requires aquaman CLI
-    if (!isAquamanInstalled()) {
+    // Check if aquaman proxy binary is available
+    const proxyAvailable = isAquamanProxyInstalled();
+
+    if (!proxyAvailable) {
       api.logger.warn(
-        "aquaman CLI not found. Install with: npm install -g aquaman-proxy"
+        "aquaman proxy not found. Install with: npm install -g aquaman-proxy"
       );
       api.logger.warn(
         "Then run: aquaman setup"
       );
+      // DO NOT call configureEnvironment() — sentinel URLs without a proxy
+      // would break all API calls (connection refused to non-existent socket)
+    } else {
+      api.logger.info("aquaman proxy found, will start proxy on gateway start");
+
+      // Configure environment variables immediately (sentinel hostname)
       configureEnvironment(api.logger, configuredServices);
-      return;
-    }
 
-    api.logger.info("aquaman CLI found, will start proxy on gateway start");
+      // Register service for proxy lifecycle management
+      api.registerService({
+        id: 'aquaman-proxy',
+        async start(ctx) {
+          ctx.logger.info("Starting aquaman proxy...");
 
-    // Configure environment variables immediately (sentinel hostname)
-    configureEnvironment(api.logger, configuredServices);
+          const started = await startProxy(ctx.logger);
+          if (started && socketPath) {
+            ctx.logger.info("Aquaman proxy started successfully");
 
-    // Register service for proxy lifecycle management
-    api.registerService({
-      id: 'aquaman-proxy',
-      async start(ctx) {
-        ctx.logger.info("Starting aquaman proxy...");
+            // Check for version mismatch between plugin and proxy
+            const proxyVersion = await getProxyVersion(socketPath);
+            if (proxyVersion && proxyVersion !== PLUGIN_VERSION) {
+              ctx.logger.warn(
+                `Warning: plugin version ${PLUGIN_VERSION} \u2260 proxy version ${proxyVersion}. ` +
+                `Update both: npm install -g aquaman-proxy && openclaw plugins install aquaman-plugin`
+              );
+            }
 
-        const started = await startProxy(ctx.logger);
-        if (started && socketPath) {
-          ctx.logger.info("Aquaman proxy started successfully");
-
-          // Check for version mismatch between plugin and proxy
-          const proxyVersion = await getProxyVersion(socketPath);
-          if (proxyVersion && proxyVersion !== PLUGIN_VERSION) {
-            ctx.logger.warn(
-              `Warning: plugin version ${PLUGIN_VERSION} \u2260 proxy version ${proxyVersion}. ` +
-              `Update both: npm install -g aquaman-proxy && openclaw plugins install aquaman-plugin`
-            );
-          }
-
-          // Activate HTTP interceptor to redirect channel traffic through proxy
-          activateHttpInterceptor(ctx.logger);
-        } else {
-          ctx.logger.error("Failed to start aquaman proxy");
-          // Check if another instance is already running
-          const defaultSock = getDefaultSocketPath();
-          const alreadyRunning = await isProxyRunning(defaultSock);
-          if (alreadyRunning) {
-            socketPath = defaultSock;
-            ctx.logger.info(
-              "Another aquaman instance is already running — using it"
-            );
-            // Load host map from existing proxy
-            const map = await loadHostMap(defaultSock);
-            dynamicHostMap = map.size > 0 ? map : FALLBACK_HOST_MAP;
+            // Activate HTTP interceptor to redirect channel traffic through proxy
             activateHttpInterceptor(ctx.logger);
           } else {
-            ctx.logger.error(
-              "No running proxy found. Check: aquaman doctor"
-            );
+            ctx.logger.error("Failed to start aquaman proxy");
+            // Check if another instance is already running
+            const defaultSock = getDefaultSocketPath();
+            const alreadyRunning = await isProxyRunning(defaultSock);
+            if (alreadyRunning) {
+              socketPath = defaultSock;
+              ctx.logger.info(
+                "Another aquaman instance is already running — using it"
+              );
+              // Load host map from existing proxy
+              const map = await loadHostMap(defaultSock);
+              dynamicHostMap = map.size > 0 ? map : FALLBACK_HOST_MAP;
+              activateHttpInterceptor(ctx.logger);
+            } else {
+              ctx.logger.error(
+                "No running proxy found. Check: openclaw aquaman doctor"
+              );
+            }
           }
+        },
+        async stop(ctx) {
+          ctx.logger.info("Stopping aquaman proxy...");
+          stopProxy();
         }
-      },
-      async stop(ctx) {
-        ctx.logger.info("Stopping aquaman proxy...");
-        stopProxy();
-      }
-    });
+      });
+    }
+
+    // --- Commands, tools, and CLI are ALWAYS registered (even without proxy) ---
+    // This ensures ClawHub users who installed the plugin but haven't run setup
+    // still get actionable commands and status information.
 
     // Register /aquaman-status slash command for humans
     api.registerCommand({
@@ -428,12 +445,7 @@ const plugin: OpenClawPluginDefinition = {
       acceptsArgs: false,
       requireAuth: true,
       async handler() {
-        const status = {
-          proxyRunning: proxyManager !== null,
-          socketPath: socketPath || getDefaultSocketPath(),
-          services: configuredServices,
-          httpInterceptorActive: httpInterceptor?.isActive() ?? false,
-        };
+        const status = getStatus(configuredServices);
         return { text: JSON.stringify(status, null, 2) };
       }
     });
@@ -444,40 +456,128 @@ const plugin: OpenClawPluginDefinition = {
         ({ program }) => {
           const aquamanCmd = program
             .command("aquaman")
-            .description("Aquaman credential management");
+            .description("Aquaman — API key protection");
 
           aquamanCmd
             .command("status")
             .description("Show aquaman proxy status")
             .action(() => {
+              const status = getStatus(configuredServices);
               console.log("\nAquaman Status:");
-              console.log(`  Proxy running: ${proxyManager !== null}`);
-              console.log(`  Socket path: ${socketPath || getDefaultSocketPath()}`);
+              console.log(`  Proxy binary: ${status.cliInstalled ? "found" : "NOT FOUND"}`);
+              console.log(`  Proxy running: ${status.proxyRunning}`);
+              console.log(`  Socket path: ${status.socketPath}`);
               console.log(`  Services: ${configuredServices.join(", ")}`);
-              console.log("\nEnvironment Variables:");
-              for (const service of configuredServices) {
-                const envKey =
-                  service === "anthropic"
-                    ? "ANTHROPIC_BASE_URL"
-                    : service === "openai"
-                      ? "OPENAI_BASE_URL"
-                      : `${service.toUpperCase()}_BASE_URL`;
-                console.log(`  ${envKey}=${process.env[envKey] ?? "(not set)"}`);
+              if (status.fix) {
+                console.log(`\n  Action needed: ${status.fix}`);
+              }
+              if (status.proxyRunning) {
+                console.log("\nEnvironment Variables:");
+                for (const service of configuredServices) {
+                  const envKey =
+                    service === "anthropic"
+                      ? "ANTHROPIC_BASE_URL"
+                      : service === "openai"
+                        ? "OPENAI_BASE_URL"
+                        : `${service.toUpperCase()}_BASE_URL`;
+                  console.log(`  ${envKey}=${process.env[envKey] ?? "(not set)"}`);
+                }
               }
             });
 
           aquamanCmd
-            .command("add <service> [key]")
-            .description("Add a credential (opens secure prompt)")
-            .action((service: string, key: string = "api_key") => {
-              console.log(`\n  Run in your terminal:\n    aquaman credentials add ${service} ${key}\n`);
+            .command("setup")
+            .description("Run the setup wizard (stores keys, configures backend)")
+            .action(async () => {
+              try {
+                const exitCode = await execAquamanProxyInteractive(['setup']);
+                if (exitCode !== 0) process.exitCode = exitCode;
+              } catch {
+                console.log("\n  Run in your terminal:\n    aquaman setup\n");
+              }
             });
 
           aquamanCmd
+            .command("doctor")
+            .description("Diagnose issues with actionable fixes")
+            .action(async () => {
+              try {
+                const result = await execAquamanProxyCli(['doctor']);
+                process.stdout.write(result.stdout);
+                if (result.stderr) process.stderr.write(result.stderr);
+                if (result.exitCode !== 0) process.exitCode = result.exitCode;
+              } catch (err: any) {
+                console.error(`Failed to run aquaman doctor: ${err.message}`);
+                process.exitCode = 1;
+              }
+            });
+
+          const credsCmd = aquamanCmd
+            .command("credentials")
+            .description("Credential management");
+
+          credsCmd
             .command("list")
             .description("List stored credentials")
-            .action(() => {
-              console.log(`\n  Run in your terminal:\n    aquaman credentials list\n`);
+            .action(async () => {
+              try {
+                const result = await execAquamanProxyCli(['credentials', 'list']);
+                process.stdout.write(result.stdout);
+                if (result.stderr) process.stderr.write(result.stderr);
+              } catch (err: any) {
+                console.error(`Failed: ${err.message}`);
+              }
+            });
+
+          credsCmd
+            .command("add <service> [key]")
+            .description("Add a credential (secure prompt)")
+            .action(async (service: string, key: string = "api_key") => {
+              try {
+                const exitCode = await execAquamanProxyInteractive(['credentials', 'add', service, key]);
+                if (exitCode !== 0) process.exitCode = exitCode;
+              } catch {
+                console.log(`\n  Run in your terminal:\n    aquaman credentials add ${service} ${key}\n`);
+              }
+            });
+
+          aquamanCmd
+            .command("policy-list")
+            .description("List configured request policy rules")
+            .action(async () => {
+              try {
+                const result = await execAquamanProxyCli(['policy', 'list']);
+                process.stdout.write(result.stdout);
+                if (result.stderr) process.stderr.write(result.stderr);
+              } catch (err: any) {
+                console.error(`Failed: ${err.message}`);
+              }
+            });
+
+          aquamanCmd
+            .command("audit-tail")
+            .description("Show recent audit log entries")
+            .action(async () => {
+              try {
+                const result = await execAquamanProxyCli(['audit', 'tail']);
+                process.stdout.write(result.stdout);
+                if (result.stderr) process.stderr.write(result.stderr);
+              } catch (err: any) {
+                console.error(`Failed: ${err.message}`);
+              }
+            });
+
+          aquamanCmd
+            .command("services-list")
+            .description("List all configured services")
+            .action(async () => {
+              try {
+                const result = await execAquamanProxyCli(['services', 'list']);
+                process.stdout.write(result.stdout);
+                if (result.stderr) process.stderr.write(result.stderr);
+              } catch (err: any) {
+                console.error(`Failed: ${err.message}`);
+              }
             });
         },
         { commands: ["aquaman"] }

--- a/packages/plugin/openclaw.plugin.json
+++ b/packages/plugin/openclaw.plugin.json
@@ -1,7 +1,11 @@
 {
   "id": "aquaman-plugin",
   "name": "Aquaman Vault",
+  "version": "0.11.0",
   "description": "Credential isolation - API keys never touch the agent process",
+  "author": "tech4242",
+  "repository": "https://github.com/tech4242/aquaman",
+  "license": "MIT",
   "permissions": {
     "env:write": ["*_BASE_URL", "GITHUB_API_URL"],
     "process:spawn": ["aquaman"],

--- a/packages/plugin/openclaw.plugin.json
+++ b/packages/plugin/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "aquaman-plugin",
-  "name": "Aquaman Vault",
+  "name": "Aquaman — API Key Protection",
   "version": "0.11.0",
-  "description": "Credential isolation - API keys never touch the agent process",
+  "description": "Protect your API keys, tokens, and secrets — they stay in your vault (Keychain, 1Password, HashiCorp Vault, Bitwarden, and more), never in the agent's memory. Block dangerous API endpoints before credentials are injected. Works with 25+ services across 6 auth modes.",
   "author": "tech4242",
   "repository": "https://github.com/tech4242/aquaman",
   "license": "MIT",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Credential isolation plugin for OpenClaw",
   "type": "module",
   "scripts": {
@@ -26,8 +26,8 @@
     "undici": "^7.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.1.11",
-    "aquaman-proxy": "0.10.0"
+    "openclaw": ">=2026.4.7",
+    "aquaman-proxy": "0.11.0"
   },
   "peerDependenciesMeta": {
     "aquaman-proxy": {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aquaman-plugin",
   "version": "0.11.0",
-  "description": "Credential isolation plugin for OpenClaw",
+  "description": "Protect API keys and secrets for OpenClaw — credentials stay in your vault, never in the agent's memory",
   "type": "module",
   "scripts": {
     "build": "echo 'OpenClaw runs TypeScript directly - no build needed'",
@@ -18,21 +18,23 @@
     "security",
     "credentials",
     "vault",
-    "1password"
+    "1password",
+    "api-key",
+    "secrets",
+    "keychain",
+    "bitwarden",
+    "credential-isolation",
+    "token-security",
+    "api-protection"
   ],
   "author": "tech4242",
   "license": "MIT",
   "dependencies": {
-    "undici": "^7.0.0"
-  },
-  "peerDependencies": {
-    "openclaw": ">=2026.4.7",
+    "undici": "^7.0.0",
     "aquaman-proxy": "0.11.0"
   },
-  "peerDependenciesMeta": {
-    "aquaman-proxy": {
-      "optional": true
-    }
+  "peerDependencies": {
+    "openclaw": ">=2026.4.7"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/packages/plugin/src/commands.ts
+++ b/packages/plugin/src/commands.ts
@@ -2,9 +2,13 @@
  * Slash commands for the OpenClaw plugin
  *
  * Provides /aquaman commands for users to interact with the plugin.
+ * Non-interactive commands execute the aquaman proxy binary directly.
+ * Interactive commands (add) show instructions since slash commands
+ * run in the chat UI where TTY is not available.
  */
 
 import type { ProxyManager } from './proxy-manager.js';
+import { execAquamanProxyCli, findAquamanProxyBinary } from './proxy-manager.js';
 import type { PluginConfig } from './config-schema.js';
 
 export interface CommandContext {
@@ -32,11 +36,13 @@ export interface PluginCommand {
  */
 export async function statusCommand(ctx: CommandContext): Promise<CommandResult> {
   const lines: string[] = [];
+  const cliInstalled = findAquamanProxyBinary() !== null;
 
   lines.push('aquaman plugin status');
   lines.push('');
   lines.push(`Backend: ${ctx.config.backend || 'keychain'}`);
   lines.push(`Services: ${(ctx.config.services || []).join(', ')}`);
+  lines.push(`Proxy binary: ${cliInstalled ? 'found' : 'NOT FOUND'}`);
 
   if (ctx.proxyManager?.isRunning()) {
     const info = ctx.proxyManager.getConnectionInfo();
@@ -46,6 +52,10 @@ export async function statusCommand(ctx: CommandContext): Promise<CommandResult>
   } else {
     lines.push('');
     lines.push('Proxy Status: Not running');
+    if (!cliInstalled) {
+      lines.push('');
+      lines.push('Setup: npm install -g aquaman-proxy && aquaman setup');
+    }
   }
 
   return {
@@ -55,7 +65,7 @@ export async function statusCommand(ctx: CommandContext): Promise<CommandResult>
 }
 
 /**
- * /aquaman add <service> - Add a credential (prompts for value)
+ * /aquaman add <service> - Add a credential (shows instructions — TTY not available in chat UI)
  */
 export async function addCommand(
   _ctx: CommandContext,
@@ -65,7 +75,8 @@ export async function addCommand(
   return {
     success: true,
     message: `To add a credential for ${service}/${key}:\n\n` +
-      `Run: aquaman credentials add ${service} ${key}\n\n` +
+      `Run: openclaw aquaman credentials add ${service} ${key}\n` +
+      `Or in terminal: aquaman credentials add ${service} ${key}\n\n` +
       `Or configure via environment variables:\n` +
       `  export AQUAMAN_${service.toUpperCase()}_${key.toUpperCase()}=<your-key>`
   };
@@ -75,30 +86,72 @@ export async function addCommand(
  * /aquaman list - List stored credentials
  */
 export async function listCommand(_ctx: CommandContext): Promise<CommandResult> {
-  return {
-    success: true,
-    message: 'Run in your terminal:\n  aquaman credentials list'
-  };
+  try {
+    const result = await execAquamanProxyCli(['credentials', 'list']);
+    return { success: result.exitCode === 0, message: result.stdout || result.stderr };
+  } catch (err: any) {
+    return { success: false, message: `Failed: ${err.message}\n\nRun in terminal: aquaman credentials list` };
+  }
+}
+
+/**
+ * /aquaman doctor - Run diagnostic checks
+ */
+export async function doctorCommand(_ctx: CommandContext): Promise<CommandResult> {
+  try {
+    const result = await execAquamanProxyCli(['doctor']);
+    return { success: result.exitCode === 0, message: result.stdout || result.stderr };
+  } catch (err: any) {
+    return { success: false, message: `Failed: ${err.message}\n\nRun in terminal: aquaman doctor` };
+  }
 }
 
 /**
  * /aquaman logs - Show recent audit entries
  */
-export async function logsCommand(_ctx: CommandContext, _count: number = 10): Promise<CommandResult> {
-  return {
-    success: true,
-    message: 'Run in your terminal:\n  aquaman audit tail'
-  };
+export async function logsCommand(_ctx: CommandContext, count: number = 10): Promise<CommandResult> {
+  try {
+    const result = await execAquamanProxyCli(['audit', 'tail', '-n', String(count)]);
+    return { success: result.exitCode === 0, message: result.stdout || result.stderr };
+  } catch (err: any) {
+    return { success: false, message: `Failed: ${err.message}\n\nRun in terminal: aquaman audit tail` };
+  }
 }
 
 /**
  * /aquaman verify - Verify audit log integrity
  */
 export async function verifyCommand(_ctx: CommandContext): Promise<CommandResult> {
-  return {
-    success: true,
-    message: 'Run in your terminal:\n  aquaman audit verify'
-  };
+  try {
+    const result = await execAquamanProxyCli(['audit', 'verify']);
+    return { success: result.exitCode === 0, message: result.stdout || result.stderr };
+  } catch (err: any) {
+    return { success: false, message: `Failed: ${err.message}\n\nRun in terminal: aquaman audit verify` };
+  }
+}
+
+/**
+ * /aquaman policy - List policy rules
+ */
+export async function policyListCommand(_ctx: CommandContext): Promise<CommandResult> {
+  try {
+    const result = await execAquamanProxyCli(['policy', 'list']);
+    return { success: result.exitCode === 0, message: result.stdout || result.stderr };
+  } catch (err: any) {
+    return { success: false, message: `Failed: ${err.message}\n\nRun in terminal: aquaman policy list` };
+  }
+}
+
+/**
+ * /aquaman services - List configured services
+ */
+export async function servicesListCommand(_ctx: CommandContext): Promise<CommandResult> {
+  try {
+    const result = await execAquamanProxyCli(['services', 'list']);
+    return { success: result.exitCode === 0, message: result.stdout || result.stderr };
+  } catch (err: any) {
+    return { success: false, message: `Failed: ${err.message}\n\nRun in terminal: aquaman services list` };
+  }
 }
 
 /**
@@ -122,6 +175,9 @@ export async function executeCommand(
     case 'list':
       return listCommand(ctx);
 
+    case 'doctor':
+      return doctorCommand(ctx);
+
     case 'logs': {
       const count = args[0] ? parseInt(args[0], 10) : 10;
       return logsCommand(ctx, count);
@@ -130,18 +186,37 @@ export async function executeCommand(
     case 'verify':
       return verifyCommand(ctx);
 
+    case 'policy':
+      return policyListCommand(ctx);
+
+    case 'services':
+      return servicesListCommand(ctx);
+
     case 'help':
     default:
       return {
         success: true,
         message: `aquaman plugin commands:
 
-  /aquaman status    - Show plugin status
-  /aquaman add       - Add a credential (shows instructions)
+  /aquaman status    - Show plugin and proxy status
+  /aquaman doctor    - Run diagnostic checks
+  /aquaman add       - Add a credential
   /aquaman list      - List stored credentials
+  /aquaman policy    - List request policy rules
+  /aquaman services  - List configured services
   /aquaman logs [n]  - Show recent audit entries
   /aquaman verify    - Verify audit log integrity
-  /aquaman help      - Show this help message`
+  /aquaman help      - Show this help message
+
+CLI commands (via terminal or openclaw aquaman <cmd>):
+
+  openclaw aquaman setup           - Run the setup wizard
+  openclaw aquaman doctor          - Diagnose issues
+  openclaw aquaman credentials list - List credentials
+  openclaw aquaman credentials add  - Add a credential (interactive)
+  openclaw aquaman policy-list     - Show policy rules
+  openclaw aquaman audit-tail      - Recent audit entries
+  openclaw aquaman services-list   - List services`
       };
   }
 }
@@ -177,6 +252,30 @@ export function getAvailableCommands(ctx: CommandContext): PluginCommand[] {
       description: 'List stored credentials',
       execute: async () => {
         const result = await listCommand(ctx);
+        return result.message;
+      }
+    },
+    {
+      name: 'doctor',
+      description: 'Run diagnostic checks',
+      execute: async () => {
+        const result = await doctorCommand(ctx);
+        return result.message;
+      }
+    },
+    {
+      name: 'policy',
+      description: 'List request policy rules',
+      execute: async () => {
+        const result = await policyListCommand(ctx);
+        return result.message;
+      }
+    },
+    {
+      name: 'services',
+      description: 'List configured services',
+      execute: async () => {
+        const result = await servicesListCommand(ctx);
         return result.message;
       }
     },

--- a/packages/plugin/src/proxy-manager.ts
+++ b/packages/plugin/src/proxy-manager.ts
@@ -9,7 +9,105 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
 import type { PluginConfig } from './config-schema.js';
+
+/**
+ * Find the aquaman proxy binary.
+ *
+ * Search order:
+ * 1. Plugin's own node_modules/.bin/aquaman (bundled dep — version-matched)
+ * 2. PATH (global install via npm install -g aquaman-proxy)
+ */
+export function findAquamanProxyBinary(): string | null {
+  // 1. Resolve from this file's location → plugin package root → node_modules/.bin/
+  const thisDir = path.dirname(fileURLToPath(import.meta.url));
+  const pluginRoot = path.resolve(thisDir, '..');
+  const localBin = path.join(pluginRoot, 'node_modules', '.bin', 'aquaman');
+  if (fs.existsSync(localBin)) {
+    return localBin;
+  }
+
+  // 2. Search PATH
+  const pathEnv = process.env.PATH || '';
+  const dirs = pathEnv.split(path.delimiter);
+  for (const dir of dirs) {
+    const candidate = path.join(dir, 'aquaman');
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Not found in this dir
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Execute an aquaman proxy CLI command (non-interactive).
+ * Captures stdout/stderr and returns them.
+ */
+export function execAquamanProxyCli(
+  args: string[],
+  options?: { timeoutMs?: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const binary = findAquamanProxyBinary();
+    if (!binary) {
+      reject(new Error('aquaman proxy binary not found. Install with: npm install -g aquaman-proxy'));
+      return;
+    }
+
+    const proc = spawn(binary, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+
+    const timeout = options?.timeoutMs ?? 30_000;
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      reject(new Error(`aquaman CLI timed out after ${timeout}ms`));
+    }, timeout);
+
+    proc.on('close', () => clearTimeout(timer));
+  });
+}
+
+/**
+ * Execute an aquaman proxy CLI command interactively (stdio: inherit).
+ * Used for commands that need TTY input (setup, credentials add).
+ */
+export function execAquamanProxyInteractive(
+  args: string[],
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const binary = findAquamanProxyBinary();
+    if (!binary) {
+      reject(new Error('aquaman proxy binary not found. Install with: npm install -g aquaman-proxy'));
+      return;
+    }
+
+    const proc = spawn(binary, args, {
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve(code ?? 1));
+  });
+}
 
 export interface ProxyConnectionInfo {
   ready: boolean;
@@ -66,7 +164,7 @@ export class ProxyManager {
       const config = this.options.config;
 
       // Find aquaman binary
-      const binaryPath = this.findAquamanBinary();
+      const binaryPath = this.findBinary();
 
       if (!binaryPath) {
         const error = new Error(
@@ -199,45 +297,10 @@ export class ProxyManager {
   }
 
   /**
-   * Find the aquaman binary
+   * Find the aquaman proxy binary
    */
-  private findAquamanBinary(): string | null {
-    // Check common locations
-    const locations = [
-      // In node_modules
-      path.join(process.cwd(), 'node_modules', '.bin', 'aquaman'),
-      path.join(process.cwd(), 'node_modules', '@aquaman', 'proxy', 'dist', 'cli', 'index.js'),
-
-      // Global install
-      '/usr/local/bin/aquaman',
-
-      // In PATH (will use which in spawn)
-      'aquaman'
-    ];
-
-    for (const loc of locations) {
-      if (loc === 'aquaman') {
-        // Check if in PATH using filesystem checks (no shell execution)
-        const pathEnv = process.env.PATH || '';
-        const dirs = pathEnv.split(path.delimiter);
-        for (const dir of dirs) {
-          const candidate = path.join(dir, 'aquaman');
-          try {
-            fs.accessSync(candidate, fs.constants.X_OK);
-            return 'aquaman';
-          } catch {
-            // Not found in this dir
-          }
-        }
-        continue;
-      }
-
-      if (fs.existsSync(loc)) {
-        return loc;
-      }
-    }
-
-    return null;
+  private findBinary(): string | null {
+    return findAquamanProxyBinary();
   }
 }
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -34,21 +34,13 @@ This package is the right side — a reverse proxy on a Unix domain socket that 
 ## Quick Start
 
 ```bash
-npm install -g aquaman-proxy
-aquaman setup                   # stores keys, installs OpenClaw plugin, applies policy defaults
-openclaw                        # proxy starts automatically via plugin
+npm install -g aquaman-proxy              # 1. install the proxy CLI
+aquaman setup                             # 2. store your API keys, install plugin
+openclaw                                  # 3. done — proxy starts automatically
 ```
 
-Standalone (without OpenClaw):
-
-```bash
-aquaman init
-aquaman credentials add anthropic api_key
-aquaman daemon                  # listens on ~/.aquaman/proxy.sock
-```
-
-> If you installed via ClawHub (`openclaw plugins install aquaman-plugin`), the proxy
-> is already bundled. Run `openclaw aquaman setup` or `aquaman setup` to store your keys.
+> **Installed via ClawHub?** The proxy is already bundled with the plugin.
+> Run `openclaw aquaman setup` to store your keys.
 
 Troubleshooting: `aquaman doctor`
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,6 +1,6 @@
 # aquaman-proxy
 
-The proxy daemon and CLI for [aquaman](https://github.com/tech4242/aquaman) — credential isolation for OpenClaw.
+The proxy daemon and CLI for [aquaman](https://github.com/tech4242/aquaman) — API key protection for OpenClaw.
 
 ```
 Agent / OpenClaw Gateway              Aquaman Proxy
@@ -46,6 +46,9 @@ aquaman init
 aquaman credentials add anthropic api_key
 aquaman daemon                  # listens on ~/.aquaman/proxy.sock
 ```
+
+> If you installed via ClawHub (`openclaw plugins install aquaman-plugin`), the proxy
+> is already bundled. Run `openclaw aquaman setup` or `aquaman setup` to store your keys.
 
 Troubleshooting: `aquaman doctor`
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,6 +1,6 @@
 # aquaman-proxy
 
-The proxy daemon and CLI for [aquaman](https://github.com/tech4242/aquaman) — API key protection for OpenClaw.
+The proxy daemon and CLI for [aquaman](https://github.com/tech4242/aquaman) — API key protection for OpenClaw. Credentials stay in your vault, never in the agent's memory.
 
 ```
 Agent / OpenClaw Gateway              Aquaman Proxy

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aquaman-proxy",
   "version": "0.11.0",
-  "description": "Credential isolation proxy daemon for OpenClaw",
+  "description": "API key protection proxy for OpenClaw — credentials stay in your vault, never in the agent's memory",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,10 +29,16 @@
   "keywords": [
     "aquaman",
     "openclaw",
-    "openclaw-plugin",
     "security",
     "credentials",
-    "proxy"
+    "vault",
+    "1password",
+    "api-key",
+    "secrets",
+    "keychain",
+    "bitwarden",
+    "proxy",
+    "api-protection"
   ],
   "author": "tech4242",
   "license": "MIT",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-proxy",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Credential isolation proxy daemon for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/test/e2e/openclaw-plugin.test.ts
+++ b/test/e2e/openclaw-plugin.test.ts
@@ -74,6 +74,7 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
       path.join(testStateDir, 'openclaw.json'),
       JSON.stringify({
         plugins: {
+          allow: ['aquaman-plugin'],
           entries: {
             'aquaman-plugin': {
               enabled: true,
@@ -123,7 +124,8 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
     it('plugin doctor reports no issues', () => {
       const result = runOpenClaw('plugins doctor');
 
-      expect(result).toContain('No plugin issues detected');
+      expect(result).not.toMatch(/error|invalid|blocked|unsafe/i);
+      expect(result).toContain('Aquaman plugin loaded');
     });
   });
 
@@ -168,7 +170,8 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
       // No path traversal or invalid name warnings
       expect(result).not.toMatch(/invalid.*path/i);
       expect(result).not.toMatch(/traversal/i);
-      expect(result).toContain('No plugin issues detected');
+      expect(result).not.toMatch(/error|blocked|unsafe/i);
+      expect(result).toContain('Aquaman plugin loaded');
     });
 
     it('plugin code passes safety scanner', () => {

--- a/test/e2e/openclaw-plugin.test.ts
+++ b/test/e2e/openclaw-plugin.test.ts
@@ -115,10 +115,9 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
     it('plugin shows as loaded', () => {
       const result = runOpenClaw('plugins list');
 
-      // Should show loaded status
+      // Should show loaded status and our plugin name
       expect(result).toContain('loaded');
-      // Should show our description
-      expect(result).toContain('API key protection');
+      expect(result).toContain('aquaman-plugin');
     });
 
     it('plugin doctor reports no issues', () => {

--- a/test/e2e/openclaw-plugin.test.ts
+++ b/test/e2e/openclaw-plugin.test.ts
@@ -118,7 +118,7 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
       // Should show loaded status
       expect(result).toContain('loaded');
       // Should show our description
-      expect(result).toContain('Credential isolation');
+      expect(result).toContain('API key protection');
     });
 
     it('plugin doctor reports no issues', () => {
@@ -134,7 +134,7 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
       const result = runOpenClaw('plugins list');
 
       // Should find the CLI (we linked it earlier)
-      expect(result).toContain('aquaman CLI found');
+      expect(result).toContain('aquaman proxy found');
     });
 
     it('sets ANTHROPIC_BASE_URL environment variable', () => {
@@ -200,7 +200,7 @@ describe.skipIf(!OPENCLAW_AVAILABLE)('OpenClaw Plugin E2E', () => {
 
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
       expect(manifest.id).toBe('aquaman-plugin');
-      expect(manifest.name).toBe('Aquaman Vault');
+      expect(manifest.name).toBe('Aquaman — API Key Protection');
     });
 
     it('has index.ts entry point', () => {

--- a/test/e2e/plugin-config-schema.test.ts
+++ b/test/e2e/plugin-config-schema.test.ts
@@ -21,7 +21,7 @@ describe('Plugin Config Schema', () => {
     manifest = JSON.parse(raw);
 
     expect(manifest.id).toBe('aquaman-plugin');
-    expect(manifest.name).toBe('Aquaman Vault');
+    expect(manifest.name).toBe('Aquaman — API Key Protection');
     expect(manifest.configSchema).toBeDefined();
     expect(manifest.configSchema.additionalProperties).toBe(false);
   });


### PR DESCRIPTION
Breaking Changes

  - Minimum OpenClaw version raised to >=2026.4.7 (was >=2026.1.11). Versions 2026.3.23–2026.4.6 have known plugin loader bugs.
  - aquaman-proxy is now a regular dependency of aquaman-plugin (was optional peer dep). Plugin package is larger but ClawHub/npm install gets a working system in one step.
  - Plugin no longer sets sentinel env vars without proxy. Previously, installing the plugin without running aquaman setup would set ANTHROPIC_BASE_URL to a non-existent socket, breaking all API calls. Now the plugin is inert
  until setup is complete.

  New Features

  - Full CLI command delegation via plugin. 8 commands available through openclaw aquaman <cmd>: setup, doctor, credentials list, credentials add, policy-list, audit-tail, services-list, status. Interactive commands (setup,
  credentials add) pass through TTY with fallback to instructions.
  - Commands registered in all modes. /aquaman-status, aquaman_status tool, and all CLI commands now work even before proxy setup — ClawHub users get actionable feedback immediately.
  - ClawHub ready. Display name "Aquaman — API Key Protection", SEO-optimized description, version/author/repository/license metadata in manifest.

  Fixes

  - findAquamanProxyBinary() resolves from plugin directory (was process.cwd()). Fixes binary resolution for ~/.openclaw/extensions/ installs.
  - Plugin SDK import fix. Removed import type { OpenClawPluginApi } from "openclaw/plugin-sdk" — broke on OpenClaw 2026.3.23+ (#53403). Types now defined locally.
  - CI bumped to OpenClaw 2026.4.9. E2E tests updated for new plugins doctor output format.
  - plugins doctor test assertions updated for 2026.4.9 output changes.
