### PR TITLE
fix: respond to ClawScan v0.11.3 findings (ASI02 + ASI03 + publisher note)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,12 @@ The `openclaw.plugin.json` manifest defines `additionalProperties: false` with o
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `backend` | `"keychain"` \| `"1password"` \| `"vault"` \| `"encrypted-file"` \| `"keepassxc"` \| `"systemd-creds"` \| `"bitwarden"` | `"keychain"` | Credential store |
-| `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy |
+| `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy. Also gates the HTTP interceptor's host map: only services in this list have their traffic redirected through the proxy (v0.11.4+). |
+| `autoGenerateAuthProfiles` | `boolean` | `true` | Auto-generate `~/.openclaw/agents/<id>/agent/auth-profiles.json` with placeholder API-key entries for `anthropic` + `openai` when the file doesn't exist. Set `false` to manage your own (v0.11.4+). |
 
 **Do NOT add extra keys** (like `proxyAutoStart`, `auditEnabled`) to `openclaw.json` — OpenClaw validates against the manifest schema and will reject them. Use `~/.aquaman/config.yaml` for advanced settings.
+
+**HTTP interceptor scope (v0.11.4+):** `activateHttpInterceptor()` in `packages/plugin/index.ts` filters the resolved host map (dynamic from proxy `/_hostmap`, or builtin `FALLBACK_HOST_MAP`) by `configuredServices` before activating the interceptor. Hosts whose service is not in the plugin's `services` config are never redirected. This narrows the attack surface (closes ClawScan ASI02) and matches user intent.
 
 ### OpenClaw Auth Profiles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,51 @@ The plugin is shipped as compiled JavaScript, not TypeScript source.
 2. `npm publish --workspace=aquaman-plugin` (its `prepublishOnly` triggers `tsc -b` → emits `dist/`)
 3. `clawhub package publish packages/plugin --source-repo tech4242/aquaman --source-commit $(git rev-parse HEAD) --source-ref main --source-path packages/plugin` (bundles the local `dist/` — `--source-repo` + `--source-commit` are mandatory together)
 
+## Pre-PR checklist
+
+Run all of these locally before opening a PR (and re-run before merge if the branch was touched). CI runs lint + typecheck + tests but does **not** run the dry-runs or smoke tests — those have caught more real issues than tests this past release.
+
+```bash
+# 1. Static checks
+npm run typecheck
+npm run lint
+
+# 2. Full test suite (~565 tests across ~36 files)
+npm test
+
+# 3. Package shape — npm tarball contents
+npm pack --dry-run --workspace=aquaman-proxy
+npm pack --dry-run --workspace=aquaman-plugin
+#   Verify the plugin tarball does NOT include:
+#   - dist/tsconfig.tsbuildinfo  (40 KB build cache; tsBuildInfoFile relocates it)
+#   - dist/src/index.{js,d.ts}, dist/src/plugin.{js,d.ts}, dist/src/commands.{js,d.ts}
+#     (excluded from compilation — old class-based plugin, standalone-test only)
+#   - .clawhub/  (excluded by files field)
+
+# 4. ClawHub publish dry-run (whenever the plugin changes)
+clawhub package publish packages/plugin \
+  --clawscan-note "$(cat packages/plugin/.clawhub/publisher-note.md)" \
+  --source-repo tech4242/aquaman \
+  --source-commit "$(git rev-parse HEAD)" \
+  --source-ref "$(git rev-parse --abbrev-ref HEAD)" \
+  --source-path packages/plugin \
+  --dry-run
+#   Requires `clawhub` CLI >= v0.15.0 (older versions don't have --clawscan-note).
+#   Verify file count + size are reasonable, --clawscan-note didn't error,
+#   and no tsbuildinfo / dead-code files leaked into the tarball.
+
+# 5. Smoke tests against a real OpenClaw install (see "Testing the OpenClaw
+#    Plugin" → "Quick proxy smoke test" + "Quick plugin CLI smoke test" below).
+#    Critical when changing: plugin index.ts, proxy-manager.ts, daemon.ts,
+#    request-policy.ts, service-registry.ts, or anything in the publish pipeline.
+```
+
+**Definition of done for the checklist:**
+- `npm test` is green (565 / 1 skipped / 0 failed at the time of writing).
+- `npm pack --dry-run` plugin tarball is ~25 KB / ~24 files. If it's growing past 30 KB or 30 files, something dead-code is leaking.
+- `clawhub package publish --dry-run` exits 0 and the file list matches `npm pack --dry-run` (minus `package-lock.json`-type npm metadata).
+- Smoke tests show the 5 expected `[plugins]` log lines on plugin load and credential injection returns the expected upstream rejection (401 from Anthropic with a fake key).
+
 ## Version Bumps
 
 Both packages are pinned to exact versions of each other and must be bumped together:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,7 +279,27 @@ The plugin is shipped as compiled JavaScript, not TypeScript source.
 **Publishing flow** (in order):
 1. `npm publish --workspace=aquaman-proxy` (its own `prepublishOnly` triggers `tsc`)
 2. `npm publish --workspace=aquaman-plugin` (its `prepublishOnly` triggers `tsc -b` → emits `dist/`)
-3. `clawhub package publish packages/plugin --source-repo tech4242/aquaman --source-commit $(git rev-parse HEAD) --source-ref main --source-path packages/plugin` (bundles the local `dist/` — `--source-repo` + `--source-commit` are mandatory together)
+3. `clawhub package publish packages/plugin --clawscan-note "$(cat packages/plugin/.clawhub/publisher-note.md)" --source-repo tech4242/aquaman --source-commit $(git rev-parse HEAD) --source-ref main --source-path packages/plugin` (bundles the local `dist/` — `--source-repo` + `--source-commit` are mandatory together; `--clawscan-note` requires `clawhub` CLI ≥ v0.15.0)
+
+### ClawHub `--clawscan-note` — what we learned
+
+The public docs (https://documentation.openclaw.ai/clawhub/cli and `/clawhub/security-audits`) are sparse on this flag — they describe the *purpose* ("context for behavior that may otherwise look unusual, such as network access, native host access, or provider-specific credentials"), confirm the note is "stored on the published version/release", and provide one example:
+
+```bash
+clawhub package publish ./plugin.tgz --clawscan-note "Native host access is limited to the local OpenClaw bridge."
+```
+
+Docs do **not** specify max length, markdown support, file conventions, edit/remove paths, or display location. The authoritative source for the technical contract is the clawhub CLI binary itself — `clawhub/dist/schema/clawScanNote.js`:
+
+- **Max 4000 characters** after `.trim()` — longer throws `ClawScan note must be at most 4000 characters.`
+- Whitespace-only normalizes to `undefined` (no note sent).
+- No format validation in the normalizer — markdown or plain text both pass through.
+- **No automatic file pickup.** Our `packages/plugin/.clawhub/publisher-note.md` path is purely a convention so the note is version-controlled and reproducible via `--clawscan-note "$(cat ...)"`; ClawHub doesn't look for that file. `.clawhub/` is excluded from the npm/ClawHub tarball via the plugin's `files` field.
+- Per-version: the note is attached to a specific published release. There's no documented post-publish update path. To change a note, publish a new version with the new note.
+
+**Style:** the docs' single example is one terse declarative sentence per concern. We write the note in plain prose (paragraph per finding, no markdown headings) so it renders well even if the ClawHub UI shows the text verbatim. Markdown rendering is not documented anywhere — when in doubt, prefer prose over markup.
+
+**Length budget:** keep the note ≤ 4000 chars after trim. Aim well under (current note is ~1200 chars). If we ever need more, split structurally rather than padding.
 
 ## Pre-PR checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,8 +311,15 @@ clawhub package publish packages/plugin \
   --source-path packages/plugin \
   --dry-run
 #   Requires `clawhub` CLI >= v0.15.0 (older versions don't have --clawscan-note).
-#   Verify file count + size are reasonable, --clawscan-note didn't error,
-#   and no tsbuildinfo / dead-code files leaked into the tarball.
+#   The publisher note is plain text or markdown, max 4000 characters AFTER
+#   .trim() (per clawhub/dist/schema/clawScanNote.js: normalizeClawScanNote).
+#   Whitespace-only normalizes to undefined and no note is sent. There is NO
+#   automatic file pickup — the path packages/plugin/.clawhub/publisher-note.md
+#   is our convention, not ClawHub's; only the --clawscan-note flag value
+#   reaches the registry. .clawhub/ is excluded from the npm/ClawHub tarball
+#   via the plugin's `files` field.
+#   Verify: file count + size are reasonable, --clawscan-note didn't error,
+#   note byte count below 4000, no tsbuildinfo / dead-code files in tarball.
 
 # 5. Smoke tests against a real OpenClaw install (see "Testing the OpenClaw
 #    Plugin" → "Quick proxy smoke test" + "Quick plugin CLI smoke test" below).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ The agent only sees a sentinel hostname (`aquaman.local`). It never sees a key, 
 | **Request policies** | Method + path rules per service, enforced before credential injection | Agent can reach Anthropic but not its admin API; can draft emails but not send them |
 | **Audit trail** | SHA-256 hash-chained logs of every credential use | Post-incident forensics, tamper detection, compliance evidence |
 
+### Proxy process
+
+The plugin spawns the `aquaman` binary from the `aquaman-proxy` npm package, declared as an exact-pinned dependency (no semver range) and published by the same author (`tech4242`). After spawn, the plugin checks the running proxy's reported version against its own and logs a warning if they disagree. The spawn is what triggers `dangerous-exec` in OpenClaw's static scanner — it's intentional and is the whole point of the plugin.
+
+### HTTP interceptor scope
+
+The plugin overrides `globalThis.fetch` to redirect channel API traffic (Slack, Discord, Telegram, …) through the local proxy. Two important constraints:
+
+- **Only services you opted into get intercepted.** As of v0.11.4, the interceptor filters its known-host map by the plugin's `services` config — channels not in `services` keep their normal direct-to-upstream behavior. The 26-entry fallback map is a *catalog* of known services, not a list of what gets intercepted on any given install.
+- **Unix Domain Socket only, no network exposure.** The interceptor sends requests through `~/.aquaman/proxy.sock`, never a TCP port.
+
+### Auth profiles
+
+OpenClaw checks `~/.openclaw/agents/<id>/agent/auth-profiles.json` before making API calls — without a placeholder entry, the request never reaches the proxy. To avoid a 6-step onboarding, the plugin auto-writes this file on first load with placeholder entries for `anthropic` and `openai` only (never arbitrary services). The proxy strips the placeholder and injects the real credential.
+
+- The plugin never overwrites an existing `auth-profiles.json`.
+- To suppress generation entirely, set `autoGenerateAuthProfiles: false` in the plugin config (v0.11.4+). Operators managing their own auth profiles can opt out cleanly.
+
+### Audit log
+
+Every credential use is recorded in `~/.aquaman/audit/current.jsonl` with a SHA-256 hash chain — local-only, no telemetry. `aquaman doctor` surfaces issues; `aquaman audit tail` shows recent entries. The `policy` config (above) lets operators block specific upstream endpoints *before* credentials are injected; denied requests return `403` with an actionable fix message.
+
+### Scanner findings
+
+`openclaw security audit --deep` reports two expected findings:
+
+- **`dangerous-exec`** on the proxy-manager module — the plugin spawns the proxy as a separate process. This is how aquaman keeps credentials out of the agent.
+- **`tools_reachable_permissive_policy`** — OpenClaw warns that plugin tools (like `aquaman_status`) are reachable when no restrictive tool profile is set. This is an environment-level advisory about your agent's tool policy, not a vulnerability in aquaman. If your agents handle untrusted input, set `"tools": { "profile": "coding" }` in `openclaw.json` to restrict which tools agents can call.
+
+ClawHub's ClawScan additionally produces a higher-level review of plugin behavior. The current scan acknowledges credential isolation, proxy spawn, the host map, the auth-profiles generation, and the audit log — see the publisher note on the ClawHub package page for context on each item.
+
+`aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.
+
 ## Request Policies
 
 OAuth scopes can't distinguish between "draft an email" and "send an email" — they're both `gmail.send`. Request policies fill that gap: allow the service, then restrict what happens inside it.
@@ -147,11 +180,3 @@ policy:
 
 **Important:** `encrypted-file` is a last-resort backend for headless Linux/CI environments without a native keyring. For better security, install `libsecret-1-dev` (for GNOME Keyring), use `systemd-creds` (Linux with TPM2), or use 1Password/Vault.
 
-## Security Audit
-
-`openclaw security audit --deep` reports two expected findings:
-
-- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the proxy as a separate process. This is how aquaman keeps credentials out of the agent.
-- **`tools_reachable_permissive_policy`** — OpenClaw warns that plugin tools (like `aquaman_status`) are reachable when no restrictive tool profile is set. This is an environment-level advisory about your agent's tool policy, not a vulnerability in aquaman. If your agents handle untrusted input, set `"tools": { "profile": "coding" }` in `openclaw.json` to restrict which tools agents can call.
-
-`aquaman setup` adds the plugin to `plugins.allow` automatically so OpenClaw knows you trust it.

--- a/packages/plugin/.clawhub/publisher-note.md
+++ b/packages/plugin/.clawhub/publisher-note.md
@@ -1,13 +1,11 @@
-Aquaman is a credential isolation plugin: API keys and channel tokens live in a separate proxy process (the `aquaman` binary from the `aquaman-proxy` npm package) and are injected into outbound requests on the fly. The agent process never sees the secret. This shape is intentional and produces several of the behavioral signals ClawScan flags. Context for each finding:
+The aquaman-proxy binary is bundled as an exact-pinned npm dependency, published by the same author (tech4242), and the plugin warns at startup if the running proxy version disagrees with its own.
 
-**ASI04 (supply chain — bundled proxy binary).** `aquaman-proxy` is declared as an exact-version dependency in this plugin's `package.json` (no semver range — npm installs exactly the version this plugin shipped against) and is published by the same author (`tech4242`) on the public npm registry. The plugin checks the running proxy's reported version against its own at startup and logs a warning if they disagree. Source: https://github.com/tech4242/aquaman.
+The HTTP interceptor only redirects traffic for services explicitly listed in the plugin's services config (v0.11.4+); channels not in services keep their normal direct-to-upstream behavior. The built-in host map is a catalog of supported services, not a list of what gets intercepted on any given install.
 
-**ASI02 (host map breadth).** v0.11.4+ filters the HTTP interceptor host map by the user's `services` config — only services the operator explicitly opted into in `openclaw.json` get their traffic redirected. The 26-entry fallback map is a *catalog* of known services, not a list of what gets intercepted on any given install.
+Auto-generated auth-profiles.json placeholders cover only anthropic and openai, never overwrite an existing file, and can be disabled via autoGenerateAuthProfiles: false in the plugin config (v0.11.4+).
 
-**ASI03 (auto-generated auth profiles).** The plugin only generates placeholder profiles for `anthropic` and `openai` (never arbitrary services) and only when `auth-profiles.json` doesn't already exist — it never overwrites an existing file. v0.11.4+ exposes `autoGenerateAuthProfiles: false` in the plugin config for operators who manage their own auth profiles.
+Spawning aquaman-proxy as a separate process is the plugin's purpose: credentials live in the proxy address space, not in the agent process. The plugin is a no-op without it.
 
-**ASI05 (dangerous-exec — spawning the proxy).** Intentional and disclosed. The plugin's entire purpose is to run the proxy as an out-of-process credential isolator. The spawn target is the `aquaman` binary from the bundled `aquaman-proxy` dependency. Without it, the plugin is a no-op.
+The audit log at ~/.aquaman/audit/current.jsonl is hash-chained and stays local with no telemetry. The policy config in ~/.aquaman/config.yaml can deny specific upstream endpoints before credential injection; denied requests return 403.
 
-**ASI07 (audit log + traffic routing).** The audit log is written to `~/.aquaman/audit/current.jsonl` with a SHA-256 hash chain — local-only, no telemetry. `aquaman doctor` surfaces issues; `aquaman audit tail` shows recent entries. Operators can constrain which upstream endpoints get proxied (and therefore credentialed) via the `policy` config in `~/.aquaman/config.yaml`; denied requests return 403 before any credential is injected.
-
-See `packages/plugin/README.md` "Security model" section for the full design rationale.
+Source: https://github.com/tech4242/aquaman

--- a/packages/plugin/.clawhub/publisher-note.md
+++ b/packages/plugin/.clawhub/publisher-note.md
@@ -1,0 +1,13 @@
+Aquaman is a credential isolation plugin: API keys and channel tokens live in a separate proxy process (the `aquaman` binary from the `aquaman-proxy` npm package) and are injected into outbound requests on the fly. The agent process never sees the secret. This shape is intentional and produces several of the behavioral signals ClawScan flags. Context for each finding:
+
+**ASI04 (supply chain — bundled proxy binary).** `aquaman-proxy` is declared as an exact-version dependency in this plugin's `package.json` (no semver range — npm installs exactly the version this plugin shipped against) and is published by the same author (`tech4242`) on the public npm registry. The plugin checks the running proxy's reported version against its own at startup and logs a warning if they disagree. Source: https://github.com/tech4242/aquaman.
+
+**ASI02 (host map breadth).** v0.11.4+ filters the HTTP interceptor host map by the user's `services` config — only services the operator explicitly opted into in `openclaw.json` get their traffic redirected. The 26-entry fallback map is a *catalog* of known services, not a list of what gets intercepted on any given install.
+
+**ASI03 (auto-generated auth profiles).** The plugin only generates placeholder profiles for `anthropic` and `openai` (never arbitrary services) and only when `auth-profiles.json` doesn't already exist — it never overwrites an existing file. v0.11.4+ exposes `autoGenerateAuthProfiles: false` in the plugin config for operators who manage their own auth profiles.
+
+**ASI05 (dangerous-exec — spawning the proxy).** Intentional and disclosed. The plugin's entire purpose is to run the proxy as an out-of-process credential isolator. The spawn target is the `aquaman` binary from the bundled `aquaman-proxy` dependency. Without it, the plugin is a no-op.
+
+**ASI07 (audit log + traffic routing).** The audit log is written to `~/.aquaman/audit/current.jsonl` with a SHA-256 hash chain — local-only, no telemetry. `aquaman doctor` surfaces issues; `aquaman audit tail` shows recent entries. Operators can constrain which upstream endpoints get proxied (and therefore credentialed) via the `policy` config in `~/.aquaman/config.yaml`; denied requests return 403 before any credential is injected.
+
+See `packages/plugin/README.md` "Security model" section for the full design rationale.

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -51,6 +51,42 @@ The `aquaman` proxy binary is bundled as an npm dependency — no separate downl
 > **Using npm?** `npm install -g aquaman-proxy && aquaman setup` does
 > the same thing. Use this if you prefer managing packages with npm.
 
+## Security model
+
+Aquaman keeps API credentials out of the agent process by running them in a separate proxy process. The agent never sees the secret — only a sentinel base URL that the proxy intercepts, authenticates, and forwards. See the [architecture diagram in the main README](https://github.com/tech4242/aquaman#architecture-decision-isolation-vs-detection).
+
+**Proxy process**
+
+- The plugin spawns the `aquaman` binary from the `aquaman-proxy` npm package, which is declared as an exact-pinned dependency (no semver range) in the plugin's `package.json` and published by the same author. After spawn the plugin checks the running proxy's reported version against the plugin's own and warns if they disagree.
+- The spawn is what triggers the `dangerous-exec` finding in OpenClaw's static scanner — it's intentional and is the whole point of the plugin.
+
+**HTTP interceptor**
+
+- Only services listed in the plugin's `services` config get their traffic redirected to the local proxy. As of v0.11.4, the interceptor filters its known-host map by your `services` list — channels you didn't opt into keep talking to the upstream directly.
+- The interceptor uses a Unix Domain Socket (no TCP, no network exposure).
+
+**Auth profiles**
+
+- On load the plugin writes `~/.openclaw/agents/<id>/agent/auth-profiles.json` with placeholder API-key entries for `anthropic` and `openai` so OpenClaw doesn't reject requests before they reach the proxy. The proxy strips the placeholder and injects the real credential.
+- The plugin never overwrites an existing `auth-profiles.json`. To suppress the generation entirely, set `autoGenerateAuthProfiles: false` in the plugin config (v0.11.4+).
+
+**Audit log**
+
+- Every credential use is recorded in `~/.aquaman/audit/current.jsonl` with a SHA-256 hash chain so tampering is detectable. The log stays local — no telemetry.
+- `aquaman doctor` surfaces audit log issues; `aquaman audit tail` shows recent entries.
+- Operators can constrain which upstream endpoints get proxied (and therefore credentialed) via the `policy` config in `~/.aquaman/config.yaml`. Denied requests return 403 before any credential is injected.
+
+### Scanner findings
+
+`openclaw security audit --deep` reports two expected findings:
+
+- **`dangerous-exec`** on the proxy-manager module — the plugin spawns the proxy as a separate process. This is how credential isolation works.
+- **`tools_reachable_permissive_policy`** — advisory about your tool policy, not an aquaman vulnerability. Set `"tools": { "profile": "coding" }` in `openclaw.json` if your agents handle untrusted input.
+
+ClawHub's ClawScan additionally produces a higher-level review of plugin behavior. The current scan acknowledges credential isolation, proxy spawn, the host map, the auth-profiles generation, and the audit log — see the publisher note on the package page for context on each item.
+
+`aquaman setup` adds the plugin to `plugins.allow` automatically.
+
 ## Available Commands
 
 All commands work via OpenClaw CLI or your terminal:
@@ -77,18 +113,10 @@ Troubleshooting: `openclaw aquaman doctor` or `aquaman doctor`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `backend` | `"keychain"` \| `"1password"` \| `"vault"` \| `"encrypted-file"` \| `"keepassxc"` \| `"systemd-creds"` \| `"bitwarden"` | `"keychain"` | Credential store |
-| `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy |
+| `services` | `string[]` | `["anthropic", "openai"]` | Services to proxy (also gates which hostnames the interceptor redirects, v0.11.4+) |
+| `autoGenerateAuthProfiles` | `boolean` | `true` | Auto-generate `auth-profiles.json` with placeholder anthropic/openai entries when the file is absent. Set `false` to manage your own (v0.11.4+) |
 
 > Advanced settings (audit, vault, request policies) go in `~/.aquaman/config.yaml`. See [request policy docs](https://github.com/tech4242/aquaman#request-policies).
-
-## Security Audit
-
-`openclaw security audit --deep` reports two expected findings:
-
-- **`dangerous-exec`** on `proxy-manager.ts` — the plugin spawns the proxy as a separate process. This is how credential isolation works.
-- **`tools_reachable_permissive_policy`** — advisory about your tool policy, not an aquaman vulnerability. Set `"tools": { "profile": "coding" }` in `openclaw.json` if your agents handle untrusted input.
-
-`aquaman setup` adds the plugin to `plugins.allow` automatically.
 
 ## Documentation
 

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -206,17 +206,31 @@ function activateHttpInterceptor(log: OpenClawPluginApi["logger"]): void {
   }
 
   // Use dynamic host map from proxy (includes custom services from services.yaml)
-  // Falls back to builtin map for backward compatibility
-  const hostMap = dynamicHostMap || FALLBACK_HOST_MAP;
+  // Falls back to builtin map for backward compatibility.
+  const sourceMap = dynamicHostMap || FALLBACK_HOST_MAP;
+
+  // Restrict interception to services the operator opted into. The interceptor
+  // only redirects traffic to hosts whose service value appears in the plugin's
+  // `services` config. Channels not in `services` keep their normal direct-to-
+  // upstream behavior. (Closes ClawScan ASI02.)
+  const allowed = new Set(configuredServices);
+  const effectiveHostMap = new Map<string, string>();
+  for (const [host, service] of sourceMap) {
+    if (allowed.has(service)) effectiveHostMap.set(host, service);
+  }
 
   httpInterceptor = createHttpInterceptor({
     socketPath,
-    hostMap,
+    hostMap: effectiveHostMap,
     log: (msg) => log.info(msg),
   });
 
   httpInterceptor.activate();
-  log.info(`HTTP interceptor active: ${hostMap.size} host patterns redirected through proxy`);
+  const skipped = sourceMap.size - effectiveHostMap.size;
+  log.info(
+    `HTTP interceptor active: ${effectiveHostMap.size} host patterns redirected through proxy` +
+      (skipped > 0 ? ` (${skipped} known patterns skipped — not in plugin services config)` : "")
+  );
 }
 
 /**
@@ -361,11 +375,20 @@ const plugin: OpenClawPluginDefinition = {
     api.logger.info("Aquaman plugin loaded");
 
     // Read services from plugin config
-    const pluginCfg = api.pluginConfig as { backend?: string; services?: string[] } | undefined;
+    const pluginCfg = api.pluginConfig as
+      | { backend?: string; services?: string[]; autoGenerateAuthProfiles?: boolean }
+      | undefined;
     configuredServices = pluginCfg?.services ?? ["anthropic", "openai"];
 
-    // Auto-generate auth-profiles.json if missing
-    ensureAuthProfiles(api.logger, configuredServices);
+    // Auto-generate auth-profiles.json if missing. Opt-out via plugin config
+    // `autoGenerateAuthProfiles: false` for operators managing their own auth
+    // profiles. (Closes ClawScan ASI03.)
+    const autoGenerateAuthProfiles = pluginCfg?.autoGenerateAuthProfiles ?? true;
+    if (autoGenerateAuthProfiles) {
+      ensureAuthProfiles(api.logger, configuredServices);
+    } else {
+      api.logger.info("auto-generation of auth-profiles.json disabled by plugin config");
+    }
 
     // Check if aquaman proxy binary is available
     const proxyAvailable = isAquamanProxyInstalled();

--- a/packages/plugin/openclaw.plugin.json
+++ b/packages/plugin/openclaw.plugin.json
@@ -27,6 +27,11 @@
         "items": { "type": "string" },
         "default": ["anthropic", "openai"],
         "description": "Services to proxy credentials for"
+      },
+      "autoGenerateAuthProfiles": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-generate ~/.openclaw/agents/<id>/agent/auth-profiles.json with placeholder API-key profiles for anthropic and openai when the file does not exist. Set to false if you manage your own auth profiles."
       }
     }
   }

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -13,10 +13,18 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
-    "composite": true
+    "composite": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "include": ["index.ts", "src/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "src/plugin.ts",
+    "src/index.ts",
+    "src/commands.ts"
+  ],
   "references": [
     { "path": "../proxy" }
   ]

--- a/test/e2e/openclaw-plugin.test.ts
+++ b/test/e2e/openclaw-plugin.test.ts
@@ -369,6 +369,127 @@ describe('Auto auth-profiles generation', () => {
   });
 });
 
+describe('Host map filter (ASI02)', () => {
+  // The plugin's activateHttpInterceptor() filters the resolved host map
+  // (dynamic from proxy, or FALLBACK_HOST_MAP) by configuredServices before
+  // handing it to createHttpInterceptor. This test replicates the filter
+  // logic directly to verify the contract.
+  function filterHostMap(
+    source: Map<string, string>,
+    configuredServices: string[]
+  ): Map<string, string> {
+    const allowed = new Set(configuredServices);
+    const out = new Map<string, string>();
+    for (const [host, service] of source) {
+      if (allowed.has(service)) out.set(host, service);
+    }
+    return out;
+  }
+
+  const sample = new Map<string, string>([
+    ['api.anthropic.com', 'anthropic'],
+    ['api.openai.com', 'openai'],
+    ['slack.com', 'slack'],
+    ['discord.com', 'discord'],
+    ['api.telegram.org', 'telegram'],
+  ]);
+
+  it('keeps only hosts whose service is in configuredServices', () => {
+    const filtered = filterHostMap(sample, ['anthropic', 'openai']);
+    expect(Array.from(filtered.keys())).toEqual(['api.anthropic.com', 'api.openai.com']);
+  });
+
+  it('returns an empty map when no configured services match', () => {
+    const filtered = filterHostMap(sample, ['mistral']);
+    expect(filtered.size).toBe(0);
+  });
+
+  it('keeps wildcard host entries when their service is configured', () => {
+    const withWildcards = new Map<string, string>([
+      ['slack.com', 'slack'],
+      ['*.slack.com', 'slack'],
+      ['discord.com', 'discord'],
+    ]);
+    const filtered = filterHostMap(withWildcards, ['slack']);
+    expect(Array.from(filtered.keys())).toEqual(['slack.com', '*.slack.com']);
+  });
+
+  it('is a strict allowlist — services not in the map are not added', () => {
+    const filtered = filterHostMap(sample, ['anthropic', 'github']);
+    expect(filtered.has('api.anthropic.com')).toBe(true);
+    expect(filtered.has('api.github.com')).toBe(false);
+  });
+});
+
+describe('autoGenerateAuthProfiles opt-out (ASI03)', () => {
+  let testDir: string;
+
+  beforeAll(() => {
+    testDir = mkdtempSync(path.join(tmpdir(), 'aquaman-authprofiles-optout-'));
+  });
+
+  afterAll(() => {
+    if (testDir) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // Plugin's register() gates ensureAuthProfiles on the flag. This test
+  // replicates the gate logic.
+  function maybeGenerate(
+    flag: boolean | undefined,
+    services: string[],
+    profilesPath: string
+  ): void {
+    const autoGenerateAuthProfiles = flag ?? true;
+    if (!autoGenerateAuthProfiles) return;
+    if (existsSync(profilesPath)) return;
+
+    const profiles: Record<string, any> = {};
+    const order: Record<string, string[]> = {};
+    for (const service of services) {
+      if (service === 'anthropic' || service === 'openai') {
+        profiles[`${service}:default`] = {
+          type: 'api_key',
+          provider: service,
+          key: 'aquaman-proxy-managed',
+        };
+        order[service] = [`${service}:default`];
+      }
+    }
+    mkdirSync(path.dirname(profilesPath), { recursive: true, mode: 0o700 });
+    writeFileSync(profilesPath, JSON.stringify({ version: 1, profiles, order }, null, 2), {
+      mode: 0o600,
+    });
+  }
+
+  it('does NOT write auth-profiles.json when flag is false', () => {
+    const profilesPath = path.join(testDir, 'off', 'auth-profiles.json');
+    maybeGenerate(false, ['anthropic', 'openai'], profilesPath);
+    expect(existsSync(profilesPath)).toBe(false);
+  });
+
+  it('writes auth-profiles.json when flag is true (default behavior)', () => {
+    const profilesPath = path.join(testDir, 'on', 'auth-profiles.json');
+    maybeGenerate(true, ['anthropic', 'openai'], profilesPath);
+    expect(existsSync(profilesPath)).toBe(true);
+  });
+
+  it('writes auth-profiles.json when flag is undefined (default true)', () => {
+    const profilesPath = path.join(testDir, 'default', 'auth-profiles.json');
+    maybeGenerate(undefined, ['anthropic', 'openai'], profilesPath);
+    expect(existsSync(profilesPath)).toBe(true);
+  });
+
+  it('manifest configSchema declares autoGenerateAuthProfiles with default true', () => {
+    const manifestPath = path.join(PLUGIN_SRC, 'openclaw.plugin.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.configSchema.properties.autoGenerateAuthProfiles).toBeDefined();
+    expect(manifest.configSchema.properties.autoGenerateAuthProfiles.type).toBe('boolean');
+    expect(manifest.configSchema.properties.autoGenerateAuthProfiles.default).toBe(true);
+  });
+});
+
 describe('Plugin Test Infrastructure', () => {
   it('correctly detects OpenClaw availability', () => {
     expect(typeof OPENCLAW_AVAILABLE).toBe('boolean');


### PR DESCRIPTION
## Summary

ClawHub's ClawScan flagged 5 findings on aquaman-plugin v0.11.3 (audited 2026-05-16, overall risk: High). This PR ships the two real over-broad defaults as code fixes, restructures the plugin README around the security model, and adds the consolidated publisher note that will be attached to v0.11.4 via clawhub's `--clawscan-note` flag at publish time.

| Finding | Severity | Response |
|---|---|---|
| ASI04 (supply chain — bundled proxy binary) | High | Publisher note: exact pin + same author + version-mismatch check |
| ASI02 (host map breadth) | Medium | **Code fix** — interceptor host map filtered by `configuredServices` |
| ASI03 (auto-generated auth-profiles) | Medium | **Code fix** — `autoGenerateAuthProfiles` opt-out flag in configSchema |
| ASI05 (dangerous-exec) | Low | Publisher note: by-design, this is the whole point |
| ASI07 (audit log + traffic routing) | Medium | Publisher note: local-only audit log, policy config available |

## Changes

- **Fix 1 (ASI02):** `activateHttpInterceptor()` in `packages/plugin/index.ts` filters the resolved host map by the plugin's `services` config. Channels not in `services` keep their normal direct-to-upstream behavior. Log message reports skipped count.
- **Fix 2 (ASI03):** `autoGenerateAuthProfiles: boolean` (default `true`) added to manifest configSchema. `register()` gates `ensureAuthProfiles()` on the flag.
- **Fix 3:** `packages/plugin/README.md` restructured. New top-level "Security model" section between Quick Start and Available Commands covering process isolation, proxy spawn rationale, interceptor scope, auth profiles, audit log, policy config. Existing "Security Audit" content moved into a "Scanner findings" subsection.
- **`packages/plugin/.clawhub/publisher-note.md`** (new file): consolidated note for `--clawscan-note`. Not in npm tarball (`files` field excludes it).
- **8 new tests** in `test/e2e/openclaw-plugin.test.ts`: 4 cases for the host filter, 4 cases for the `autoGenerateAuthProfiles` gate including manifest schema validation.
- **CLAUDE.md** Plugin Config Schema table updated with both new behaviors.

## Backward compatibility

- Default behavior preserved: `autoGenerateAuthProfiles` defaults to `true`, host filter defaults to whatever services the user already had in `openclaw.json` plugin config.
- Users who relied on the broad fallback to redirect traffic to channels (slack, discord, telegram, etc.) without listing them in `services` would no longer see that redirect. Documented in README and CLAUDE.md as a deliberate tightening.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm test` — 564 passed / 1 skipped / 0 failed (33 tests in `openclaw-plugin.test.ts`, up from 25)
- [ ] CI green
- [ ] After merge: cut `release/v0.11.4`, bump versions, publish via npm proxy → npm plugin → `clawhub package publish packages/plugin --clawscan-note "$(cat packages/plugin/.clawhub/publisher-note.md)" --source-repo tech4242/aquaman --source-commit $(git rev-parse HEAD) --source-ref main --source-path packages/plugin`
- [ ] Re-scan v0.11.4 on ClawHub. Expected: static-analysis `dangerous_exec` drops from 2 to 1 (chore PR #17 + this), ASI02 + ASI03 resolved by code fixes, ASI04/05/07 acknowledged via publisher note. Overall risk likely Medium (vs current High).

Refs: ClawHub audit 2026-05-16 on package `tech4242/aquaman-plugin` (5 findings, risk: High).
