### PR TITLE
release: v0.11.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/openclaw:latest
 
 # Install aquaman proxy (includes credential stores, audit, CLI)
-RUN npm install -g aquaman-proxy@0.11.3
+RUN npm install -g aquaman-proxy@0.11.4
 
 # Install plugin into OpenClaw extensions
 # Note: docker build context must contain a prebuilt plugin/dist/ directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "description": "API key protection for OpenClaw — credentials stay in your vault, never in the agent's memory",
   "type": "module",

--- a/packages/plugin/openclaw.plugin.json
+++ b/packages/plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "aquaman-plugin",
   "name": "Aquaman — API Key Protection",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Protect your API keys, tokens, and secrets — they stay in your vault (Keychain, 1Password, HashiCorp Vault, Bitwarden, and more), never in the agent's memory. Block dangerous API endpoints before credentials are injected. Works with 25+ services across 6 auth modes.",
   "author": "tech4242",
   "repository": "https://github.com/tech4242/aquaman",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-plugin",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Protect API keys and secrets for OpenClaw — credentials stay in your vault, never in the agent's memory",
   "type": "module",
   "scripts": {
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "undici": "^7.0.0",
-    "aquaman-proxy": "0.11.3"
+    "aquaman-proxy": "0.11.4"
   },
   "peerDependencies": {
     "openclaw": ">=2026.5.7"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-proxy",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "API key protection proxy for OpenClaw — credentials stay in your vault, never in the agent's memory",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

v0.11.4 — ClawScan v0.11.3 response release. Two over-broad defaults tightened, plugin tarball trimmed 45%, Pre-PR checklist documented, publisher note ready for attachment via `--clawscan-note` at publish time.

This release bundles the work from the two recently-merged PRs:

- **#17** — chore: real build pipeline for aquaman-plugin (compiled `dist/` ships, no `.ts` source)
- **#18** — fix: respond to ClawScan v0.11.3 findings (ASI02 + ASI03 + publisher note)

Plus the version bumps in this PR.

## Changelog

### Security tightening (ClawScan response)

- **ASI02** — `activateHttpInterceptor()` now filters its resolved host map by the operator's `services` config. Channels not listed keep direct-to-upstream behavior.
- **ASI03** — `autoGenerateAuthProfiles: boolean` (default `true`) added to the plugin's configSchema. Operators managing their own `auth-profiles.json` can set `false`.
- **ASI04 / ASI05 / ASI07** — addressed via the consolidated `--clawscan-note` published at release time (text at `packages/plugin/.clawhub/publisher-note.md`).

### Plugin build pipeline (chore)

- `tsc -b` build pipeline made real; `prepublishOnly` hook compiles `dist/`.
- Plugin ships only compiled JS (`files: ["dist", "openclaw.plugin.json", "LICENSE", "README.md"]`), no `.ts` source in the published tarball.
- `openclaw.extensions` points at `./dist/index.js` (matches OpenClaw 2026.5.x's preference for compiled output).
- `tsBuildInfoFile` relocated outside `dist/`; dead-code `src/{index,plugin,commands}.ts` excluded from emit.
- Plugin tarball: **45.2 kB / 37 files → 24.9 kB / 24 files** (-45%).
- Static-analysis `dangerous-exec` finding count drops from 2 → 1 (only the compiled `dist/src/proxy-manager.js` ships).

### Bug fixes

- `aquaman init` is now idempotent for the audit directory — heals a missing dir even when `config.yaml` already exists, honors a custom `audit.logDir`.
- `aquaman doctor` expands `~` in `config.audit.logDir` before the existence check (no more false-positive "Audit directory missing" when the config stores the literal `~/.aquaman/audit`).

### Docs

- New "Security Model" section in both the repo README and `packages/plugin/README.md`, with subsections covering proxy process, HTTP interceptor scope, auth profiles, audit log, and scanner findings. The old "Security Audit" section is demoted to a "Scanner findings" subsection.
- New `## Pre-PR checklist` section in CLAUDE.md (typecheck / lint / tests / `npm pack --dry-run` / `clawhub package publish --dry-run` / smoke tests) with definition-of-done thresholds.
- New `### ClawHub --clawscan-note — what we learned` subsection in CLAUDE.md capturing what the docs say vs what the binary enforces (4000 char cap, no file convention, per-version semantics).

### Compatibility (unchanged)

- Peer dep floor: `openclaw >=2026.5.7`
- Build refs: `openclawVersion: 2026.5.12`, `pluginSdkVersion: 2026.5.12`

## Pre-PR checklist results

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm test` — 564 passed / 1 skipped / 0 failed (36 files)
- [x] `npm pack --dry-run` proxy — 110.6 kB / 95 files
- [x] `npm pack --dry-run` plugin — 24.9 kB / 24 files
- [x] `clawhub package publish --dry-run` — 24 files / 24919 bytes, note accepted, no leaks
- [ ] CI green
- [ ] After merge: cut tag, publish chain — npm proxy → npm plugin → clawhub plugin (with `--clawscan-note "$(cat packages/plugin/.clawhub/publisher-note.md)"`)
- [ ] Re-check ClawScan on the v0.11.4 page (expected: static-analysis `dangerous_exec` from 2 → 1, ASI02 + ASI03 resolved, ASI04/05/07 acknowledged via publisher note)
