### PR TITLE
chore: fix aquaman-proxy build script for clean checkouts

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "prepublishOnly": "npm run build",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

One-line fix. The proxy's `build` script was `tsc` but `packages/proxy/tsconfig.json` has `composite: true`. In composite mode, plain `tsc` is a no-op on a fully clean checkout (no buildinfo and no dist) — it exits 0 without emitting.

Concrete failure mode: on a freshly-cloned tree, `npm publish --workspace=aquaman-proxy` runs `prepublishOnly → npm run build → tsc`, which silently exits 0 without producing any output, and ships an **empty 3.1 kB / 3-file tarball** instead of the expected 110 kB / 95 files.

We dodged this for v0.11.3 and v0.11.4 because `npm run typecheck` (which uses `tsc -b packages/proxy packages/plugin`) ran beforehand and pre-populated `dist/`. Pure luck.

## Change

`packages/proxy/package.json`:
```diff
- "build": "tsc",
+ "build": "tsc -b",
```

## Test plan

- [x] Reproduce: `rm -rf packages/proxy/dist packages/proxy/tsconfig.tsbuildinfo && npm run build:proxy` — with `tsc`, dist is not created; with `tsc -b`, 24 entries emitted.
- [x] `npm pack --dry-run --workspace=aquaman-proxy` after the fix: 110.6 kB / 95 files (matches v0.11.3 + v0.11.4 baseline).
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm test` — 564 passed / 1 skipped / 0 failed
- [x] `clawhub package publish --dry-run` — unchanged (plugin tarball is 24 files / 24919 bytes either way; this fix is proxy-only)
- [ ] CI green
- [ ] After merge: include in next release (likely v0.11.5 or roll into the next feature release; no urgency to cut a release just for this).

## Refs

Flagged in the v0.11.4 release notes under "Flagged for future releases".
