### PR TITLE
chore(security): SECURITY.md + CodeQL + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,13 @@
 version: 2
 updates:
-  # npm workspace root (covers packages/proxy, plugin, coder via workspaces)
+  # npm workspaces monorepo: ONE entry, all manifests via `directories`.
+  # Single root package-lock.json — security updates were already covered by
+  # the lockfile; listing the workspace dirs makes VERSION updates reach the
+  # runtime deps declared in packages/*/package.json (the part "/" alone missed).
   - package-ecosystem: npm
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/*"
     schedule:
       interval: weekly
       day: monday
@@ -11,6 +16,9 @@ updates:
         update-types: ["minor", "patch"]
     open-pull-requests-limit: 5
     ignore:
+      # Workspace-internal exact pins, managed by the release process (the CD
+      # version gate asserts them) — dependabot must never touch these.
+      - dependency-name: aquaman-proxy
       # Dev-only transitives locked inside the `openclaw` devDependency (e2e
       # tests): openclaw@2026.6.6 exact-pins undici@8.3.0 and pulls its own
       # hono, so security bumps (undici 8.5.0, hono 4.12.25) are unresolvable

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,17 @@ updates:
       minor-and-patch:
         update-types: ["minor", "patch"]
     open-pull-requests-limit: 5
+    ignore:
+      # Dev-only transitives locked inside the `openclaw` devDependency (e2e
+      # tests): openclaw@2026.6.6 exact-pins undici@8.3.0 and pulls its own
+      # hono, so security bumps (undici 8.5.0, hono 4.12.25) are unresolvable
+      # from this repo — the update jobs fail red on every retry otherwise.
+      # Re-check on each openclaw CI bump and drop these when it unpins.
+      # NOTE: aquaman-plugin's RUNTIME undici is ^7.x — outside this ignore
+      # range, still fully covered by security updates.
+      - dependency-name: undici
+        versions: [">=8.0.0 <9.0.0"]
+      - dependency-name: hono
 
   # Python plugin (packages/hermes — zero runtime deps, covers dev/build tooling)
   - package-ecosystem: uv

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # npm workspace root (covers packages/proxy, plugin, coder via workspaces)
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 5
+
+  # Python plugin (packages/hermes — zero runtime deps, covers dev/build tooling)
+  - package-ecosystem: uv
+    directory: "/packages/hermes"
+    schedule:
+      interval: weekly
+      day: monday
+
+  # GitHub Actions pins in ci.yml / cd.yml / codeql.yml
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 6 * * 1'   # weekly, Monday 06:30 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+Aquaman is a credential-isolation proxy — security reports get priority over everything else.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security problems.** Use GitHub's private vulnerability reporting:
+
+**[Report a vulnerability](https://github.com/tech4242/aquaman/security/advisories/new)** (Security tab → "Report a vulnerability")
+
+You can expect an acknowledgement within **7 days**. For confirmed vulnerabilities in shipped code, the fix and the release ship in one motion (so the fix is not visible in the public history ahead of a patched version), followed by a GitHub security advisory crediting the reporter (unless you prefer otherwise). There is no bug bounty.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| Latest minor of the 0.x line (all packages) | ✅ |
+| Anything older | ❌ — upgrade first |
+
+The four packages (`aquaman-proxy`, `aquaman-plugin`, `aquaman-coder` on npm; `aquaman-hermes` on PyPI) are released in lockstep; a fix bumps all of them.
+
+## Scope
+
+**In scope:** anything that breaks aquaman's stated guarantees —
+
+- Credential exposure to the agent process (values reaching the agent's memory, transcript, or environment outside the documented broker flow)
+- Bypasses of the request-policy engine, the loopback token gate, or UDS/file permissions
+- Audit-log tampering that `verifyIntegrity()` fails to detect
+- Vulnerabilities in the packages' own code or their published artifacts (including the release pipeline)
+
+**Out of scope:**
+
+- Vulnerabilities in the vault backends themselves (1Password, Bitwarden, HashiCorp Vault, KeePassXC, OS keychains, systemd) — report those upstream
+- Vulnerabilities in the agent hosts (OpenClaw, Claude Code, Hermes) — report those upstream
+- Prompt-injection *content* attacks against the agent. Note the design boundary: **aquaman prevents credential exfiltration, not credential use.** A prompt-injected agent running as the same OS user can call the same proxy the legitimate code calls; the request-policy engine is the control that limits what a used credential can do. Reports that reduce to "the agent can use the proxy" are the documented threat model, not a vulnerability — but bypasses *of the policy engine itself* are very much in scope.
+- Redaction misses for secrets aquaman did not inject (the redactor is documented as defense-in-depth, not a guarantee)
+
+## Where the security documentation lives
+
+This file is the **process**: how to report, what's supported. It intentionally makes no design claims of its own. For those:
+
+- **Design** — the security model in the [README](README.md#security-model-in-depth) (process isolation, request policies, tamper-evident audit, credential caching trade-offs)
+- **Control evidence** — [`docs/compliance/`](docs/compliance/): MITRE ATLAS and NIST SP 800-53 mappings, each claim backed by a runnable conformance test under [`test/compliance/`](test/compliance/) (`npx vitest run test/compliance/`)
+
+If this file and those documents ever disagree, those documents win — and please report the discrepancy.


### PR DESCRIPTION
## What

Security-hygiene follow-up from the open-source risk review:

- **SECURITY.md** — private vulnerability reporting process (GitHub advisories), supported versions, and explicit scope including the exfiltration-vs-use design boundary. Process only: design claims stay in the README security model and `docs/compliance/` so there is one source of truth per claim.
- **CodeQL workflow** — `javascript-typescript`, `python` (packages/hermes), and `actions` analyzers; runs on push/PR to main plus a weekly cron.
- **dependabot.yml** — weekly version updates: npm workspace (minor/patch grouped), uv for the hermes package, and GitHub Actions pins.

## Why

Aquaman is a public credential proxy — the most realistic attack on users is supply-chain (compromised release, vulnerable dep, workflow tampering), not breaking the proxy design. Private vuln reporting and dependabot alerts are already enabled repo-side; this PR adds the pieces that live in the tree.

## Verification

- CodeQL runs on this PR itself (proves the workflow parses and the analyzers initialize).
- dependabot config takes effect on merge to the default branch.
- SECURITY.md appears in the Security tab / report-a-vulnerability flow once merged.