### PR TITLE
chore(deps): dependabot grouping + npm majors policy + Coverage fix for bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,20 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+      # Group SECURITY-update PRs too (separate from the version-update group).
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
     open-pull-requests-limit: 5
     ignore:
+      # MAJORS POLICY: no automatic semver-major PRs for npm. Majors in this
+      # tree always need human migration (vitest 1->4, oxlint 0.x->1.x) or must
+      # track the runtime we actually run (@types/node vs CI's Node version) —
+      # they are deliberate, scheduled chores. NOTE: this also suppresses
+      # security-update PRs that would require a major; the alert stays visible
+      # on the dashboard and the fix is the manual migration.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       # Workspace-internal exact pins, managed by the release process (the CD
       # version gate asserts them) — dependabot must never touch these.
       - dependency-name: aquaman-proxy
@@ -37,9 +49,15 @@ updates:
       interval: weekly
       day: monday
 
-  # GitHub Actions pins in ci.yml / cd.yml / codeql.yml
+  # GitHub Actions pins in ci.yml / cd.yml / codeql.yml. Majors stay ALLOWED
+  # here (unlike npm): action major tags are runner-runtime migrations that
+  # GitHub deprecates on its own schedule — pins rot until CI breaks unprompted.
+  # One grouped weekly PR keeps them reviewable.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
       day: monday
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,11 @@ jobs:
           npm ci --legacy-peer-deps --ignore-scripts
           npm rebuild keytar esbuild oxlint
       - run: npm run test:coverage
-      - uses: codecov/codecov-action@v5
+      - name: Upload coverage to Codecov
+        # Dependabot-triggered runs get no repo secrets, so the upload can only
+        # fail there — skip it (tests above still run and gate the PR).
+        if: github.actor != 'dependabot[bot]'
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info


### PR DESCRIPTION
## What

Follow-up to the first dependabot fan-out (13 PRs, #27–#39, all closed):

1. **npm majors banned** (`dependency-name: "*"` + `version-update:semver-major` ignore). Majors here always need human work — vitest 1→4 failed CI outright, @types/node must track the Node major CI actually runs — so they become deliberate chores. Caveat documented in-file: this also suppresses security-update PRs that require a major; the alert stays visible and the fix is the manual migration (the critical vitest alert is exactly this, tracked in the roadmap).
2. **GitHub Actions majors stay allowed but grouped** into one weekly PR. Action major tags are runner-runtime migrations that GitHub deprecates on its own schedule — banning them means pins rot until CI breaks unprompted; grouping keeps it to one reviewable one-line-per-action PR.
3. **Security-update PRs grouped** via `applies-to: security-updates`.
4. **Coverage fix:** dependabot-triggered workflow runs get no repo secrets, so the codecov upload failed on every bot PR (`fail_ci_if_error: true`). The upload step is now skipped for `dependabot[bot]`; tests still run and gate.

## Expected effect

Merging this triggers a fresh dependabot run against the new config: expect ~2 grouped PRs (npm minors/patches; actions incl. majors) instead of 13 singles, all green-capable.

## Verification

- `dependabot.yml` schema validates on merge (Insights → Dependabot shows config errors if any).
- The reopened grouped PRs should show no Coverage failure.