### PR TITLE
chore(lint): clean up findings surfaced by oxlint 0.18

### DIFF
--- a/packages/coder/src/adapters/claude-code/hook.ts
+++ b/packages/coder/src/adapters/claude-code/hook.ts
@@ -24,7 +24,7 @@
 // merged core/). There is no separate `aquaman-core` npm package since
 // v0.7.0; the vitest alias resolves the same path for tests.
 import { redact } from 'aquaman-proxy';
-import { findProjectForCwd, loadProjects, parseRef } from '../../projects.js';
+import { findProjectForCwd, loadProjects } from '../../projects.js';
 import { BrokerClient } from '../../broker-client.js';
 
 export interface HookEvent {

--- a/packages/coder/src/adapters/claude-code/setup.ts
+++ b/packages/coder/src/adapters/claude-code/setup.ts
@@ -115,6 +115,7 @@ export function uninstallClaudeCodeHooks(opts: SetupOptions = {}): SetupResult {
         .map((entry) => ({
           ...entry,
           hooks: entry.hooks.filter((h) =>
+            !h.command?.includes(hookCommand) &&
             !h.command?.includes('aquaman coder hook') &&
             !h.command?.includes('aquaman-coder hook')
           ),

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -81,20 +81,6 @@ import { loadHostMap, isProxyRunning, getProxyVersion } from "./src/proxy-health
  * Find an executable in PATH using filesystem checks (no shell execution).
  * Avoids execSync("which ...") which triggers dangerous-exec security audit flags.
  */
-function findInPath(name: string): string | null {
-  const pathEnv = process.env.PATH || "";
-  const dirs = pathEnv.split(path.delimiter);
-  for (const dir of dirs) {
-    const candidate = path.join(dir, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // Not found or not executable in this dir
-    }
-  }
-  return null;
-}
 
 // Read plugin version from package.json
 const pluginPkgPath = path.join(path.dirname(new URL(import.meta.url).pathname), 'package.json');

--- a/packages/plugin/src/plugin.ts
+++ b/packages/plugin/src/plugin.ts
@@ -7,7 +7,7 @@
  */
 
 import { type PluginConfig, mergeConfig, defaultConfig } from './config-schema.js';
-import { createProxyManager, type ProxyManager, type ProxyConnectionInfo } from './proxy-manager.js';
+import { createProxyManager, type ProxyManager } from './proxy-manager.js';
 import { executeCommand, type CommandContext, type CommandResult, getAvailableCommands, type PluginCommand } from './commands.js';
 import { HttpInterceptor, createHttpInterceptor } from './http-interceptor.js';
 

--- a/packages/plugin/src/proxy-manager.ts
+++ b/packages/plugin/src/proxy-manager.ts
@@ -44,7 +44,6 @@ export function pickProxyEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.Proce
 }
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import type { PluginConfig } from './config-schema.js';
 

--- a/packages/plugin/test/openclaw-contract.test.ts
+++ b/packages/plugin/test/openclaw-contract.test.ts
@@ -140,7 +140,7 @@ describe('OpenClaw Plugin Contract', () => {
       const properties = ConfigSchema.properties;
 
       // Each property should have a type
-      for (const [key, value] of Object.entries(properties)) {
+      for (const [, value] of Object.entries(properties)) {
         expect(value).toHaveProperty('type');
       }
     });

--- a/packages/plugin/test/plugin.test.ts
+++ b/packages/plugin/test/plugin.test.ts
@@ -29,7 +29,7 @@ vi.mock('../src/proxy-manager.js', () => ({
     }),
     waitForReady: vi.fn().mockResolvedValue(undefined)
   })),
-  createProxyManager: vi.fn().mockImplementation((opts) => ({
+  createProxyManager: vi.fn().mockImplementation((_opts) => ({
     start: vi.fn().mockResolvedValue({
       ready: true,
       socketPath: '/tmp/aquaman-test/proxy.sock',

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -31,7 +31,7 @@ import {
 
 import { fileURLToPath } from 'node:url';
 
-import { createCredentialProxy, type CredentialProxy } from '../daemon.js';
+import { createCredentialProxy } from '../daemon.js';
 import { createServiceRegistry, ServiceRegistry } from '../service-registry.js';
 import { createOpenClawIntegration, authProfilesAreSqliteOnly } from '../openclaw/integration.js';
 import { createHermesIntegration, detectHermes } from '../hermes/integration.js';
@@ -1439,7 +1439,7 @@ openclaw
             console.error(`  Check VAULT_ADDR (${vaultAddr}) and VAULT_TOKEN.`);
             process.exit(1);
           }
-        } catch (err) {
+        } catch {
           console.error(`  Cannot reach Vault at ${vaultAddr}.`);
           process.exit(1);
         }

--- a/packages/proxy/src/core/audit/logger.ts
+++ b/packages/proxy/src/core/audit/logger.ts
@@ -338,7 +338,7 @@ export class AuditLogger {
         }
 
         previousHash = entry.hash;
-      } catch (parseError) {
+      } catch {
         errors.push(`Entry ${i}: failed to parse JSON`);
       }
     }

--- a/packages/proxy/src/core/credentials/backends/onepassword.ts
+++ b/packages/proxy/src/core/credentials/backends/onepassword.ts
@@ -70,7 +70,7 @@ export class OnePasswordStore implements CredentialStore {
     // Check if signed in
     try {
       this.runOp(['account', 'get']);
-    } catch (error) {
+    } catch {
       throw new Error('Not signed in to 1Password. Run: op signin');
     }
   }

--- a/packages/proxy/src/core/credentials/backends/systemd-creds.ts
+++ b/packages/proxy/src/core/credentials/backends/systemd-creds.ts
@@ -44,7 +44,7 @@ function execFileAsync(
         resolve({ stdout: out, stderr: errOut });
       }
     });
-    if (input != null) {
+    if (input !== null && input !== undefined) {
       proc.stdin!.write(input);
       proc.stdin!.end();
     }

--- a/packages/proxy/src/core/utils/config.ts
+++ b/packages/proxy/src/core/utils/config.ts
@@ -89,7 +89,7 @@ export function loadConfig(): WrapperConfig {
       const content = fs.readFileSync(configPath, 'utf-8');
       const userConfig = parseYaml(content) as Partial<WrapperConfig>;
       config = mergeConfig(defaultConfig, userConfig);
-    } catch (error) {
+    } catch {
       console.error(`Warning: Failed to load config from ${configPath}, using defaults`);
       config = defaultConfig;
     }

--- a/packages/proxy/src/openclaw/integration.ts
+++ b/packages/proxy/src/openclaw/integration.ts
@@ -7,7 +7,6 @@
  * - Launching OpenClaw with the correct configuration
  */
 
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { generateOpenClawEnv, writeEnvFile, appendToShellRc, formatEnvForDisplay } from './env-writer.js';

--- a/test/e2e/cli-migrate.test.ts
+++ b/test/e2e/cli-migrate.test.ts
@@ -4,9 +4,9 @@
  * Tests the guided migration flow with temp environments.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { spawn } from 'node:child_process';
-import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { createTempEnv, type TempEnv } from '../helpers/temp-env.js';
 

--- a/test/e2e/cli-plugin-mode.test.ts
+++ b/test/e2e/cli-plugin-mode.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { spawn, type ChildProcess } from 'node:child_process';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import { tmpSocketPath, cleanupSocket, udsFetch } from '../helpers/uds-proxy.js';
+import { udsFetch } from '../helpers/uds-proxy.js';
 import { createTempEnv, type TempEnv } from '../helpers/temp-env.js';
 
 const CLI_PATH = path.resolve('packages/proxy/src/cli/index.ts');

--- a/test/e2e/openclaw-plugin.test.ts
+++ b/test/e2e/openclaw-plugin.test.ts
@@ -32,7 +32,7 @@ function isOpenClawInstalled(): boolean {
 // any runtime logs that a command emits.
 function runOpenClaw(args: string): string {
   const testBinDir = path.join(testStateDir, 'bin');
-  const { VITEST, ...env } = process.env;
+  const { VITEST: _vitest, ...env } = process.env;
   return execSync(`npx openclaw ${args} 2>&1`, {
     encoding: 'utf-8',
     env: {

--- a/test/e2e/request-policy.test.ts
+++ b/test/e2e/request-policy.test.ts
@@ -2,7 +2,7 @@
  * E2E tests for request-level policy enforcement through the full proxy stack.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { createCredentialProxy, type CredentialProxy, type PolicyConfig } from 'aquaman-proxy';
 import { MemoryStore } from 'aquaman-core';
 import type { RequestInfo } from 'aquaman-proxy';

--- a/test/unit/oauth-token-cache.test.ts
+++ b/test/unit/oauth-token-cache.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the OAuth client credentials token cache.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { OAuthTokenCache, createOAuthTokenCache } from '../../packages/proxy/src/oauth-token-cache.js';
 import { MemoryStore } from 'aquaman-core';
 import type { OAuthConfig } from 'aquaman-proxy';

--- a/test/unit/openclaw/integration.test.ts
+++ b/test/unit/openclaw/integration.test.ts
@@ -101,7 +101,6 @@ describe('OpenClawIntegration', () => {
       const env = { 'TEST_VAR': 'test_value' };
 
       // Mock process.cwd to return tempDir without actually changing directory
-      const originalCwd = process.cwd;
       vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
 
       try {

--- a/test/unit/request-policy.test.ts
+++ b/test/unit/request-policy.test.ts
@@ -9,8 +9,7 @@ import {
   validatePolicyConfig,
   loadPolicyFromConfig,
   getDefaultPolicyPresets,
-  type PolicyConfig,
-  type ServicePolicy
+  type PolicyConfig
 } from 'aquaman-proxy';
 
 describe('matchPathPattern', () => {


### PR DESCRIPTION
## What

Dependabot's grouped npm PR (#42) bumps oxlint 0.2.18 → 0.18.1, which adds rules that flag 24 findings in existing code — that's the Lint & Typecheck failure on #42. This PR fixes the code so #42 can rebase and go green.

All mechanical except two worth review:

- **`uninstallClaudeCodeHooks` latent bug fixed**: it accepted `opts.hookCommand` but the removal filter hardcoded the two default command strings — a custom hook command would never be uninstalled. The filter now honors the option (default behavior unchanged).
- **Dead `findInPath()` removed** from `packages/plugin/index.ts` — superseded by `proxy-manager.ts`'s `findAquamanProxyBinary` in v0.11.0.

Everything else: unused catch params → bare `catch`, unused imports/vars removed, one `!=` → explicit `!== null && !== undefined` (semantics preserved).

## Verification

- Clean under **both** oxlint 0.2.18 (current main) and 0.18.1 (post-#42): 0 warnings, 0 errors.
- `tsc -b` all packages: clean. All 85 tests in touched files pass; full suite runs in CI.

## Merge order

1. This PR
2. Comment `@dependabot rebase` on #42 → its lint goes green → merge #42