### PR TITLE
chore(deps): agent-host deps are manual compat events, not auto-bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,14 @@ updates:
       # Workspace-internal exact pins, managed by the release process (the CD
       # version gate asserts them) — dependabot must never touch these.
       - dependency-name: aquaman-proxy
+      # AGENT-HOST COMPAT DEPS ARE MANUAL. openclaw is CalVer — dependabot's
+      # minor/patch classification is meaningless, and "patch-looking" releases
+      # have broken us before (2026.3.23 SDK import removal, 2026.6.5
+      # auth-profiles SQLite move). Host support moves deliberately via the
+      # compat-watch process (CI pin bump + deep checks + ROADMAP notes), never
+      # via auto-bump. (Claude Code and Hermes have no npm dep — their compat
+      # is protocol-level and verified against live docs at release time.)
+      - dependency-name: openclaw
       # Dev-only transitives locked inside the `openclaw` devDependency (e2e
       # tests): openclaw@2026.6.6 exact-pins undici@8.3.0 and pulls its own
       # hono, so security bumps (undici 8.5.0, hono 4.12.25) are unresolvable
@@ -48,6 +56,10 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    ignore:
+      # Same agent-host policy as openclaw on the npm side: if hermes-agent is
+      # ever added as a test dep, its bumps are manual compat events.
+      - dependency-name: hermes-agent
 
   # GitHub Actions pins in ci.yml / cd.yml / codeql.yml. Majors stay ALLOWED
   # here (unlike npm): action major tags are runner-runtime migrations that


### PR DESCRIPTION
Rescues the second commit from #43, which was pushed to that branch a few minutes **after** the merge and never landed on main.

- **`openclaw` excluded from dependabot** (npm): it's CalVer, so minor/patch classification is meaningless — and patch-looking releases broke the plugin twice (2026.3.23 SDK import removal, 2026.6.5 auth-profiles SQLite move). Host support moves via the deliberate compat-watch process: CI pin bump + deep checks + compat notes.
- **`hermes-agent` ignore on the uv side** — documents the same policy; no such dep exists today, takes effect if a test dep is ever added.
- **Claude Code needs no rule** — hook protocol, not a package dependency.

After this merges, comment `@dependabot recreate` on #42 so the group regenerates **without** the openclaw 2026.6.6→2026.6.11 bump (leaving @types/node patch, oxlint, tsx — green against the #43 lint fixes already on main).