### PR TITLE
chore(deps-dev): oxlint 0.18.1 + tsx 4.23.0 + @types/node 20.19.43 (supersedes #45)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aquaman",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aquaman",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -17,7 +17,7 @@
         "@vitest/coverage-v8": "^1.2.0",
         "ajv": "^8.17.0",
         "openclaw": "^2026.6.6",
-        "oxlint": "^0.2.0",
+        "oxlint": "^0.18.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
         "vitest": "^1.2.0"
@@ -608,9 +608,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.2.18.tgz",
-      "integrity": "sha512-DpPId0O8hHh1/PjbtJSMi3DvgK5ol49hB+jiogYGXvBPOF2/8/tG1v7dtbACx4pcorUMu4EHHKHigasnx114cQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.18.1.tgz",
+      "integrity": "sha512-FqDrcQJmEGNkgmZgI4wbCrGyJl1tiRZa3udxvyYaXag8W80A0zLFNCyWVvHIgUJ0DHlZjRc7O72xUGjiyvQrqQ==",
       "cpu": [
         "arm64"
       ],
@@ -622,9 +622,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.2.18.tgz",
-      "integrity": "sha512-hdnPhG/nxF2F8YI9lg3uYMH1ZYxSKiDPu2srey1Xvo2LZChNnvbvxXNS5UYAxG9f/U6VbH4WYfUcqbNZW5Tnzw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.18.1.tgz",
+      "integrity": "sha512-YUcyWBJdNuMcJxAwdV/i25/kvnKrVsA+vLn7SsL87cAwiD//rqGdOixk0r8sKUYa71Kx3h0Fg2ToUOjdE6ddYw==",
       "cpu": [
         "x64"
       ],
@@ -636,9 +636,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.2.18.tgz",
-      "integrity": "sha512-bhCHYlIn8I5bw5AulQKhYJzanLFoi7mgIkqzfiJibCrGrQh3IKv3h0k8bWHqLEYMmufhGz7yhS96oY3Pe0K1Aw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.18.1.tgz",
+      "integrity": "sha512-ol3jhmUv5VI/omMrt6DkwY/jVTSVJlflFyU1SnSb/BuVVf3TyBiCHmZ4wVtcrcT5k3sWjrvYWw2kSozvmuE4tg==",
       "cpu": [
         "arm64"
       ],
@@ -650,9 +650,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.2.18.tgz",
-      "integrity": "sha512-TbZONlryL36xWLUCNRhYZ0m92io6hiN0Ho8ez4T5BoTWwaKwyTdAvpbH7vFDlVDAsp33GB81DXsFSAjPq8PIng==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.18.1.tgz",
+      "integrity": "sha512-iKDj1ZwlU4KpXuIL1qkVP6NJzri2VSJreqXCIAe1Bf5RZXMAGSO3xjldgiX+HBvFOKSBIarLcqONYDbYco9uaQ==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +664,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.2.18.tgz",
-      "integrity": "sha512-Leupfl0E85BC1t8zB+vqUeeKami+Lo/8HiihLUQAbjz+O8J2WuNaOmt/GURK5jINQhEASBw8dnhNFBMKYe6ZgA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.18.1.tgz",
+      "integrity": "sha512-A3g+fZhlOivUdK7xU/IrbhBcMHig5GLrfMX0HYjXL1fiSqKYu9n1o1p42WpT6KfPL3L2uncSg/iyg7hspcN6qA==",
       "cpu": [
         "x64"
       ],
@@ -678,9 +678,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.2.18.tgz",
-      "integrity": "sha512-THG4LZ8KeCy87E4tHqC765acRW0dyXdgzqERi3idjSupCH8juTpk9UfZVcpxcqEicXnEuZDkBQpO8nboyFng3Q==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.18.1.tgz",
+      "integrity": "sha512-LA02SdATWZEZBy8ZZpR2GlUbDg7+Jq1/WKkywMXqxdClkcoyyFozj8aQD2iTMKELSra4OSyqqZpOYroqjSSKmw==",
       "cpu": [
         "x64"
       ],
@@ -692,9 +692,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.2.18.tgz",
-      "integrity": "sha512-X/boJsMQiuO2Wfu3eabWefFlb0+O5oSXjcG0gmIE9aySNMy/pVyCno2/RGy+0f4xSjBZXmamCsEoQp/E8NeDQQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.18.1.tgz",
+      "integrity": "sha512-FNL+OxDflqLGXRgLxfBM/X4RnLYgtOKTsb1mNSqsjSCEfUi1Oqivh7KvZ09IfAMZeJ85/fL6EI6hSOyY7nNYUg==",
       "cpu": [
         "arm64"
       ],
@@ -706,9 +706,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.2.18.tgz",
-      "integrity": "sha512-LmwDhDaZYd20WKmHPeITYNazGVUBFvs7D9+WJ+ecx+bX/6euFp8j+e/4sUzxR5gk6pecqyA6WEld52Gy6W92jg==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.18.1.tgz",
+      "integrity": "sha512-W+aVE9Siqs6Oe3NDaDOTTOYsN9X3znl+whfqWK1EcLpqJXX1kdB8Hf45HkGjqnHoFoP96GRgUnXQHQvmUybjvg==",
       "cpu": [
         "x64"
       ],
@@ -1093,9 +1093,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6017,29 +6017,30 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.2.18.tgz",
-      "integrity": "sha512-/6tR2hm9vN/cjJarItkDPeSWDqPbkQ6pVDzePR2La5cNA+kn1Gt7k0ZHxcpTuhZOI/lhRD2z4C0v/m9kja/0cQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.18.1.tgz",
+      "integrity": "sha512-JGcQvbhd00Qb+nq4f9sYYRh7mZIb0K/7rbMepNdJDMzo8pbmBpx1N2XOG61RjHDsNnY6ImAmVk3h4QVwFenwUQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
+        "oxc_language_server": "bin/oxc_language_server",
         "oxlint": "bin/oxlint"
       },
       "engines": {
-        "node": ">=14.*"
+        "node": ">=8.*"
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "0.2.18",
-        "@oxlint/darwin-x64": "0.2.18",
-        "@oxlint/linux-arm64-gnu": "0.2.18",
-        "@oxlint/linux-arm64-musl": "0.2.18",
-        "@oxlint/linux-x64-gnu": "0.2.18",
-        "@oxlint/linux-x64-musl": "0.2.18",
-        "@oxlint/win32-arm64": "0.2.18",
-        "@oxlint/win32-x64": "0.2.18"
+        "@oxlint/darwin-arm64": "0.18.1",
+        "@oxlint/darwin-x64": "0.18.1",
+        "@oxlint/linux-arm64-gnu": "0.18.1",
+        "@oxlint/linux-arm64-musl": "0.18.1",
+        "@oxlint/linux-x64-gnu": "0.18.1",
+        "@oxlint/linux-x64-musl": "0.18.1",
+        "@oxlint/win32-arm64": "0.18.1",
+        "@oxlint/win32-x64": "0.18.1"
       }
     },
     "node_modules/p-limit": {
@@ -6574,9 +6575,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
-      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7307,10 +7308,10 @@
     },
     "packages/coder": {
       "name": "aquaman-coder",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "aquaman-proxy": "0.12.0",
+        "aquaman-proxy": "0.13.0",
         "commander": "^11.0.0",
         "yaml": "^2.3.4"
       },
@@ -7325,31 +7326,11 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/coder/node_modules/aquaman-proxy": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/aquaman-proxy/-/aquaman-proxy-0.12.0.tgz",
-      "integrity": "sha512-3YTD5khK/wjwx5RWzACL4OU+qRZMt59A95/MH4zYdCKrpI6NBEqX3efuBLmSf0WLVDL6kOExsdyxPS/VmkYchQ==",
-      "license": "MIT",
-      "dependencies": {
-        "argon2": "^0.44.0",
-        "commander": "^12.0.0",
-        "kdbxweb": "^2.1.1",
-        "yaml": "^2.3.4"
-      },
-      "bin": {
-        "aquaman": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "keytar": "^7.9.0"
-      }
-    },
     "packages/coder/node_modules/aquaman-proxy/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7357,10 +7338,10 @@
     },
     "packages/plugin": {
       "name": "aquaman-plugin",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "aquaman-proxy": "0.12.0",
+        "aquaman-proxy": "0.13.0",
         "undici": "^7.25.0"
       },
       "devDependencies": {
@@ -7374,39 +7355,9 @@
         "openclaw": ">=2026.5.7"
       }
     },
-    "packages/plugin/node_modules/aquaman-proxy": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/aquaman-proxy/-/aquaman-proxy-0.12.0.tgz",
-      "integrity": "sha512-3YTD5khK/wjwx5RWzACL4OU+qRZMt59A95/MH4zYdCKrpI6NBEqX3efuBLmSf0WLVDL6kOExsdyxPS/VmkYchQ==",
-      "license": "MIT",
-      "dependencies": {
-        "argon2": "^0.44.0",
-        "commander": "^12.0.0",
-        "kdbxweb": "^2.1.1",
-        "yaml": "^2.3.4"
-      },
-      "bin": {
-        "aquaman": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "keytar": "^7.9.0"
-      }
-    },
-    "packages/plugin/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/proxy": {
       "name": "aquaman-proxy",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "argon2": "^0.44.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@vitest/coverage-v8": "^1.2.0",
     "ajv": "^8.17.0",
     "openclaw": "^2026.6.6",
-    "oxlint": "^0.2.0",
+    "oxlint": "^0.18.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
     "vitest": "^1.2.0"


### PR DESCRIPTION
## What

The same three bumps as dependabot's #45, regenerated with npm itself.

## Why not just merge #45

Its dependabot-regenerated `package-lock.json` **stripped `dev: true` from the whole openclaw subtree** (openclaw + nested undici/tar/protobufjs; verified by diffing the lockfiles — main has the flags, #45 doesn't, oxlint/tsx kept theirs). That leaks openclaw's vulnerable transitives into the blocking `npm audit --omit=dev` shipped-deps gate — that's the Lint & Typecheck failure. Merging #45 would land the corrupted lockfile on main and turn main's CI red.

## Verification (local, against this branch)

- `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities (openclaw subtree correctly dev-flagged)
- `npm run lint` (oxlint **0.18.1**) → 0 warnings, 0 errors (the #43 cleanup holds)
- `tsc -b` all packages → clean
- Full suite runs in CI on this PR

## After merging

Close #45 (`@dependabot ignore` not needed — it'll auto-close as superseded on next run, or close manually). If dependabot's next weekly npm PR shows the same symptom, check `dev` flags on the openclaw lockfile entry before trusting the audit step's verdict — it's a dependabot lockfile-regeneration bug, likely tied to the aquaman-plugin → openclaw peerDependency edge.