### PR TITLE
chore(compat): OpenClaw 2026.6.10 + Hermes 0.18.0 + Claude Code 2.1.202

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,16 +39,6 @@ updates:
       # via auto-bump. (Claude Code and Hermes have no npm dep — their compat
       # is protocol-level and verified against live docs at release time.)
       - dependency-name: openclaw
-      # Dev-only transitives locked inside the `openclaw` devDependency (e2e
-      # tests): openclaw@2026.6.6 exact-pins undici@8.3.0 and pulls its own
-      # hono, so security bumps (undici 8.5.0, hono 4.12.25) are unresolvable
-      # from this repo — the update jobs fail red on every retry otherwise.
-      # Re-check on each openclaw CI bump and drop these when it unpins.
-      # NOTE: aquaman-plugin's RUNTIME undici is ^7.x — outside this ignore
-      # range, still fully covered by security updates.
-      - dependency-name: undici
-        versions: [">=8.0.0 <9.0.0"]
-      - dependency-name: hono
 
   # Python plugin (packages/hermes — zero runtime deps, covers dev/build tooling)
   - package-ecosystem: uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,11 @@ jobs:
           path: |
             /usr/local/lib/node_modules/openclaw
             /usr/local/bin/openclaw
-          key: openclaw-${{ runner.os }}-node24-2026.6.6
+          key: openclaw-${{ runner.os }}-node24-2026.6.10
       - name: Install openclaw
         if: steps.cache-openclaw.outputs.cache-hit != 'true'
         run: |
-          npm install -g openclaw@2026.6.6 --ignore-scripts
+          npm install -g openclaw@2026.6.10 --ignore-scripts
           npm rebuild -g openclaw
       - run: npx vitest run test/e2e/openclaw-plugin.test.ts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ The `aquaman-coder` package extends aquaman to AI coding agents. v0.12.0 ships t
 - `adapters/claude-code/setup.ts` — Writes `~/.claude/settings.json` atomically (mode 0o600, parent dir 0o700). Idempotent via substring-match on the hook command.
 - `cli/index.ts` — Commander-based CLI: `setup <agent>`, `project list/add/remove`, `get <ref>`, `exec <cmd...>`, `hook`, `doctor`.
 
-**Critical hook-protocol gotcha:** Earlier drafts of the adapter used fabricated fields (`additionalEnvVars` for PreToolUse env injection, `updatedToolOutput` for PostToolUse rewriting). These do not exist — Claude Code silently ignores them. The real protocol only supports `permissionDecision` / `permissionDecisionReason` / `updatedInput` / `additionalContext` for PreToolUse and `additionalContext` for PostToolUse. When extending, **verify against the live Claude Code docs**, not training-data memory.
+**Critical hook-protocol notes (re-verified 2026-07-07 against live docs @ Claude Code 2.1.202):** Our contract (`permissionDecision` / `permissionDecisionReason` / `updatedInput` for PreToolUse; `additionalContext` for PostToolUse; exit-2 via stderr) is unchanged and fully supported. Two fields that did NOT exist when the adapter was written now DO (added ~2.1.170+): (1) **`PreToolUse.additionalEnvVars`** — env-var injection. **Deliberately NOT used for credentials**: hook stdout JSON would carry real values through Claude Code's process/memory, which is exactly what the broker + `exec`-wrapper isolation exists to avoid. (2) **`PostToolUse.updatedToolOutput`** — true output rewriting for all tools. Not adopted yet; tracked as a defense-in-depth feature (redact non-Bash tool outputs, e.g. Read/Grep surfacing on-disk secrets). When extending, **verify against the live Claude Code docs**, not training-data memory.
 
 **Project map example** (`~/.aquaman/projects.yaml`):
 
@@ -264,6 +264,8 @@ arrives as the provider api_key Hermes sends (`x-api-key` for Anthropic,
   `_PORT`/`_TOKEN` (no `_HOST` override — the bind stays loopback).
 - CLI: `aquaman hermes setup|doctor|status|configure`. `loadLoopbackOptions()` refuses to
   start an enabled-but-tokenless listener (an untokened loopback proxy would be open).
+
+**Hermes >=0.17/0.18 operational notes (verified 2026-07-07 vs hermes-agent 0.18.0):** the base-URL detection, plugin contract, `--version` format, and `HERMES_HOME`/`.env` loading are all compatible — no integration changes needed. Three additions to know: (1) **managed scope** — a root-owned `/etc/hermes/.env` overrides `~/.hermes/.env` AND shell exports; if it pins our env vars the proxy is silently bypassed (`aquaman hermes doctor`/`status` now detect this via `managedScopeShadowedKeys()`); (2) `gateway.multiplex_profiles` (off by default) scopes env per profile — multi-profile users need the aquaman block in each profile's env; (3) Hermes cron jobs pairing `provider: anthropic` with an explicit off-host `base_url` override are refused by its 0.18 exfil guard — jobs inheriting the session runtime (our env-var path) are unaffected.
 
 **Python plugin (`packages/hermes/`, optional sugar):** `aquaman-hermes` on PyPI. A
 stdlib-only directory plugin (`plugin.yaml` + `register(ctx)`) installed into

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/ws": "^8.5.10",
         "@vitest/coverage-v8": "^4.1.10",
         "ajv": "^8.17.0",
-        "openclaw": "^2026.6.6",
+        "openclaw": "2026.6.10",
         "oxlint": "^0.18.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
@@ -566,6 +566,20 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2089,6 +2103,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -2180,9 +2219,9 @@
       }
     },
     "node_modules/openclaw": {
-      "version": "2026.6.6",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.6.6.tgz",
-      "integrity": "sha512-oMYoQ8a7zummw1tD+AX98yYLzqoq0tQmYWHG65AA0ZivgzmOb2oD0cVdhcWP9IT3opkHdJ5vBdWywUe6xWQXtw==",
+      "version": "2026.6.10",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.6.10.tgz",
+      "integrity": "sha512-LcooND2tBQw8A+kc1Ujltu3lg30bJ0w7XaeRy7eYzobb8BBdcW6DOGbwJL4vpj1vl9+gjRceOtlh5nh9OARcug==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
@@ -2208,7 +2247,6 @@
         "clawpdf": "0.3.0",
         "commander": "14.0.3",
         "croner": "10.0.1",
-        "cross-spawn": "7.0.6",
         "diff": "9.0.0",
         "dotenv": "17.4.2",
         "express": "5.2.1",
@@ -2232,12 +2270,12 @@
         "qrcode": "1.5.4",
         "quickjs-wasi": "3.0.0",
         "rastermill": "0.3.1",
-        "tar": "7.5.15",
+        "tar": "7.5.16",
         "tree-sitter-bash": "0.25.1",
         "tslog": "4.10.2",
         "typebox": "1.1.39",
         "typescript": "6.0.3",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "web-push": "3.6.7",
         "web-tree-sitter": "0.26.9",
         "ws": "8.21.0",
@@ -2646,6 +2684,79 @@
         "undici": ">=8.3.0 <9"
       }
     },
+    "node_modules/openclaw/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/openclaw/node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
@@ -2684,6 +2795,16 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/openclaw/node_modules/@types/retry": {
       "version": "0.12.5",
@@ -3980,9 +4101,9 @@
       }
     },
     "node_modules/openclaw/node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4864,13 +4985,24 @@
       }
     },
     "node_modules/openclaw/node_modules/protobufjs": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.0.tgz",
-      "integrity": "sha512-iriNhQ57SYA5Jbdi+41AyPdx6jPPkFO7DODzkOBmqFhgYn/JzX2HxgxYPY18eQAs3CP/AWqtPvkWn8rclRAxdQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
         "long": "^5.3.2"
       },
       "engines": {
@@ -5532,9 +5664,9 @@
       }
     },
     "node_modules/openclaw/node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5706,14 +5838,21 @@
       }
     },
     "node_modules/openclaw/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/openclaw/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/openclaw/node_modules/unpipe": {
       "version": "1.0.0",
@@ -6681,6 +6820,17 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/ws": "^8.5.10",
     "@vitest/coverage-v8": "^4.1.10",
     "ajv": "^8.17.0",
-    "openclaw": "^2026.6.6",
+    "openclaw": "2026.6.10",
     "oxlint": "^0.18.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/packages/coder/README.md
+++ b/packages/coder/README.md
@@ -100,7 +100,7 @@ Claude Code / Codex / OpenCode / Cursor
 The hook uses Claude Code's real protocol (verified against the live docs):
 
 - **PreToolUse** on Bash: emits `{ hookSpecificOutput: { permissionDecision: "allow", updatedInput: { command: "aquaman-coder exec -- sh -c '...'" } } }`. Claude Code runs the rewritten command in its child shell; the wrapper does the broker resolve.
-- **PostToolUse**: emits `{ hookSpecificOutput: { additionalContext: "aquaman: tool output contained secret patterns…" } }` if the redactor finds secrets in the output. Note: PostToolUse can't *rewrite* output (the tool already ran). Real scrubbing happens inside `aquaman-coder exec`'s stdout pipeline. PostToolUse is purely an alert.
+- **PostToolUse**: emits `{ hookSpecificOutput: { additionalContext: "aquaman: tool output contained secret patterns…" } }` if the redactor finds secrets in the output. Real scrubbing happens inside `aquaman-coder exec`'s stdout pipeline; the PostToolUse hook is an alert. (Claude Code ~2.1.170+ added `updatedToolOutput` for true output rewriting — planned as an additional redaction layer for non-Bash tools. It also added `PreToolUse.additionalEnvVars`, which we deliberately do NOT use for credentials: hook output transits the agent process, defeating the isolation.)
 
 See [`docs/PACKAGES.md`](../../docs/PACKAGES.md) for cross-package import rules.
 

--- a/packages/hermes/README.md
+++ b/packages/hermes/README.md
@@ -71,3 +71,11 @@ aquaman-hermes uninstall
 - It depends only on the Python standard library.
 - Only LLM providers (Anthropic, OpenAI) are wired today. Channels/other providers are
   out of scope for the Hermes path (no base-URL lever to redirect them).
+- Hermes >=0.17 "managed scope": a root-owned `/etc/hermes/.env` overrides
+  `~/.hermes/.env` — if an admin pins the `ANTHROPIC_*`/`OPENAI_*` vars there, the
+  proxy is bypassed. `aquaman hermes doctor` detects and flags this.
+- With `gateway.multiplex_profiles` enabled (off by default), env is scoped per
+  profile — add the aquaman block to each profile's env file.
+- Hermes 0.18's cron exfil guard refuses cron jobs that pair a named provider with
+  an off-host `base_url` override; normal jobs inheriting the session runtime (the
+  env vars aquaman writes) are unaffected.

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -17,8 +17,8 @@
       "minGatewayVersion": "2026.5.7"
     },
     "build": {
-      "openclawVersion": "2026.6.6",
-      "pluginSdkVersion": "2026.6.6"
+      "openclawVersion": "2026.6.10",
+      "pluginSdkVersion": "2026.6.10"
     }
   },
   "keywords": [

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -38,6 +38,7 @@ import { createCredentialProxy } from '../daemon.js';
 import { createServiceRegistry, ServiceRegistry } from '../service-registry.js';
 import { createOpenClawIntegration, authProfilesAreSqliteOnly } from '../openclaw/integration.js';
 import { createHermesIntegration, detectHermes } from '../hermes/integration.js';
+import { managedScopeShadowedKeys, HERMES_MANAGED_ENV_PATH } from '../hermes/config-writer.js';
 import { loadPolicyFromConfig, validatePolicyConfig, getDefaultPolicyPresets, matchPolicy, type ServicePolicy } from '../request-policy.js';
 import { stringify as yamlStringify, parse as yamlParse } from 'yaml';
 
@@ -1148,6 +1149,11 @@ hermes
     } catch { /* unreadable */ }
     console.log(`  ~/.hermes/.env:    ${envWired ? aqua('wired') : 'not wired'}  (${envPath})`);
 
+    const shadowed = managedScopeShadowedKeys(integration.configureHermes());
+    if (shadowed.length > 0) {
+      console.log(`  Managed scope:     ⚠ ${HERMES_MANAGED_ENV_PATH} pins ${shadowed.join(', ')} — proxy bypassed for these keys`);
+    }
+
     const info = await detectHermes(config.hermes?.binaryPath || 'hermes');
     console.log(`  Hermes CLI:        ${info.installed ? aqua(`v${info.version}`) : 'not found'}`);
 
@@ -1204,6 +1210,16 @@ hermes
       }
     } catch {
       fail(`Could not read ${envPath}`);
+    }
+
+    // 3b. Hermes >=0.17 managed scope: /etc/hermes/.env overrides ~/.hermes/.env
+    {
+      const shadowed = managedScopeShadowedKeys(integration.configureHermes());
+      if (shadowed.length > 0) {
+        fail(`Hermes managed scope (${HERMES_MANAGED_ENV_PATH}) pins ${shadowed.join(', ')} — it overrides ~/.hermes/.env, so the proxy is BYPASSED for these keys. Remove them from the managed file or point them at the proxy.`);
+      } else {
+        pass('No managed-scope override of aquaman env vars');
+      }
     }
 
     // 4. Per-service vault credentials resolve

--- a/packages/proxy/src/hermes/config-writer.ts
+++ b/packages/proxy/src/hermes/config-writer.ts
@@ -129,6 +129,34 @@ export function writeHermesEnv(env: Record<string, string>, filePath: string): v
   fs.writeFileSync(filePath, merged, { mode: 0o600 });
 }
 
+/**
+ * Hermes >= 0.17 "managed scope": a root-owned /etc/hermes/.env is loaded LAST
+ * with override=true, beating both ~/.hermes/.env and shell exports. If an
+ * admin pins any of the env vars aquaman manages, the proxy is silently
+ * bypassed for those keys. Returns the managed keys that file shadows (empty
+ * when the file is absent/unreadable). `managedEnvPath` is parameterized for
+ * tests; production callers use the default.
+ */
+export const HERMES_MANAGED_ENV_PATH = '/etc/hermes/.env';
+
+export function managedScopeShadowedKeys(
+  ourEnv: Record<string, string>,
+  managedEnvPath: string = HERMES_MANAGED_ENV_PATH
+): string[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(managedEnvPath, 'utf-8');
+  } catch {
+    return []; // absent or unreadable (non-root) — nothing to warn about
+  }
+  const pinned = new Set<string>();
+  for (const line of content.split('\n')) {
+    const m = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+    if (m) pinned.add(m[1]);
+  }
+  return Object.keys(ourEnv).filter((k) => pinned.has(k));
+}
+
 /** Format env vars for display (dry-run / export output). */
 export function formatHermesEnvForDisplay(env: Record<string, string>): string {
   return Object.entries(env)

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -58,7 +58,9 @@ export {
   hermesWiredServices,
   getHermesEnvPath,
   writeHermesEnv,
-  formatHermesEnvForDisplay
+  formatHermesEnvForDisplay,
+  managedScopeShadowedKeys,
+  HERMES_MANAGED_ENV_PATH
 } from './hermes/config-writer.js';
 
 export {

--- a/test/unit/hermes/config-writer.test.ts
+++ b/test/unit/hermes/config-writer.test.ts
@@ -7,6 +7,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+  managedScopeShadowedKeys,
   generateHermesEnv,
   hermesWiredServices,
   getHermesEnvPath,
@@ -111,5 +112,57 @@ describe('writeHermesEnv', () => {
     expect(blockCount).toBe(1);
     expect(content).toContain('ANTHROPIC_API_KEY=tok2');
     expect(content).not.toContain('ANTHROPIC_API_KEY=tok1');
+  });
+});
+
+describe('managedScopeShadowedKeys (Hermes >=0.17 managed scope)', () => {
+  let dir: string;
+  const OUR_ENV = {
+    ANTHROPIC_BASE_URL: 'http://127.0.0.1:8585/anthropic',
+    ANTHROPIC_API_KEY: 'aqm_lb_token',
+    OPENAI_BASE_URL: 'http://127.0.0.1:8585/openai/v1',
+    OPENAI_API_KEY: 'aqm_lb_token',
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aquaman-managed-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (content: string) => {
+    const p = path.join(dir, '.env');
+    fs.writeFileSync(p, content);
+    return p;
+  };
+
+  it('returns empty when the managed file does not exist', () => {
+    expect(managedScopeShadowedKeys(OUR_ENV, path.join(dir, 'missing.env'))).toEqual([]);
+  });
+
+  it('returns empty when the managed file pins unrelated keys', () => {
+    const p = write('SOME_OTHER_KEY=value\nHTTP_PROXY=http://proxy\n');
+    expect(managedScopeShadowedKeys(OUR_ENV, p)).toEqual([]);
+  });
+
+  it('detects a pinned key aquaman manages', () => {
+    const p = write('ANTHROPIC_API_KEY=sk-ant-direct\n');
+    expect(managedScopeShadowedKeys(OUR_ENV, p)).toEqual(['ANTHROPIC_API_KEY']);
+  });
+
+  it('detects multiple pinned keys, export-prefixed and indented lines included', () => {
+    const p = write('  export ANTHROPIC_BASE_URL=https://api.anthropic.com\nOPENAI_API_KEY = sk-openai\n');
+    expect(managedScopeShadowedKeys(OUR_ENV, p).sort()).toEqual(['ANTHROPIC_BASE_URL', 'OPENAI_API_KEY']);
+  });
+
+  it('ignores comments and non-assignment lines', () => {
+    const p = write('# ANTHROPIC_API_KEY=commented-out\nnot an assignment\n');
+    expect(managedScopeShadowedKeys(OUR_ENV, p)).toEqual([]);
+  });
+
+  it('returns empty for an unreadable path instead of throwing', () => {
+    expect(managedScopeShadowedKeys(OUR_ENV, path.join(dir, 'nodir', 'x.env'))).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

The deliberate host-compat pass (per the agent-host dependabot policy from #44). Research: per-release OpenClaw delta, tag-to-tag Hermes source diff, live Claude Code docs verification.

### OpenClaw 2026.6.6 → **2026.6.10** (deliberately not .11)

- **2026.6.11 is a known-bad release**: confirmed empty-tool-output regression (openclaw#98528, would break our `aquaman_status` tool) + a memory_search race. Exact-pinned to .10; re-check at 2026.7.1 stable.
- Delta .8–.10: no plugin API / manifest-schema / scanner-rule changes; auth-profiles SQLite import path unchanged (`doctor --fix` flow holds).
- **Bonus:** .10 ships patched transitives (undici 8.5.0, tar 7.5.16, hono 4.12.25) → **full-tree `npm audit` is now 0 vulnerabilities**; the undici/hono dependabot ignores are dropped. All 16 dependabot alerts should clear on merge.
- Noted for the roadmap: SecretRef manifest (openclaw#82326) is shipped + documented; auth-profiles.json is now officially 'legacy'. Migration stays a separate deliberate PR.

### Hermes 0.16.0 → 0.18.0 (contract verification — not a dep)

- All 5 surfaces compatible (base-URL detection rewritten in 0.17 but `/anthropic` mapping holds; plugin contract byte-identical; `--version` format unchanged). **Verified live**: keyless `hermes-agent==0.18.0` install → our plugin installs, enables, and registers.
- **New check in `aquaman hermes doctor`/`status`**: Hermes ≥0.17 'managed scope' loads root-owned `/etc/hermes/.env` with override — if it pins our env vars, the proxy is silently bypassed. Now detected and flagged (+6 unit tests).
- Docs: multiplex-profiles note, 0.18 cron `base_url` exfil-guard note.

### Claude Code 2.1.202 (protocol verification — not a dep)

- Hook contract unchanged; no code changes. Docs corrected for two fields that now exist (~2.1.170+): `additionalEnvVars` (documented as **rejected for credentials** — hook stdout transits the agent process, defeating isolation) and `updatedToolOutput` (filed as a future non-Bash redaction layer).

## Verification

- 836 TS tests + 25 pytest green against the new pins (incl. OpenClaw e2e against 2026.6.10 locally); lint + `tsc -b` clean
- `npm audit` (full tree): **0 vulnerabilities**; `--omit=dev`: 0
- Lockfile `dev` flags intact (`openclaw: dev=true`)
- Live Hermes 0.18.0: version-regex match, plugin install/enable/list all pass