### PR TITLE
ci(cd): stamp all version fields from the release tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,11 +19,20 @@ jobs:
       version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - id: check
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME#v}"          # v0.13.0 -> 0.13.0
           echo "Release tag version: $TAG"
+          # Source of truth is the tag: stamp every version field from it, so a
+          # forgotten manual bump can't block or mis-version a release.
+          node scripts/set-version.mjs "$TAG"
+          # The asserts below now GUARD the setter — they only fail if a NEW
+          # version field was added to the repo without being added to
+          # scripts/set-version.mjs. (Kept intentionally — cheap insurance.)
           fail=0
           assert() { # name, actual
             if [ "$2" != "$TAG" ]; then echo "::error::$1 = '$2' (expected '$TAG')"; fail=1
@@ -58,6 +67,7 @@ jobs:
       - run: |
           npm ci --legacy-peer-deps --ignore-scripts
           npm rebuild keytar esbuild oxlint
+      - run: node scripts/set-version.mjs "${{ needs.validate-version.outputs.version }}"   # stamp versions from the tag
       - run: npm run build
       - run: npm test            # ship only what passes
       # Order matters: proxy first — plugin & coder pin it at an exact version.
@@ -78,9 +88,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Test before publish
         working-directory: packages/hermes
         run: uv run --with pytest python -m pytest tests/ -q
+      - name: Stamp version from the release tag
+        run: node scripts/set-version.mjs "${{ needs.validate-version.outputs.version }}"
       - name: Build sdist + wheel
         working-directory: packages/hermes
         run: uv build
@@ -100,6 +115,7 @@ jobs:
       - run: |
           npm ci --legacy-peer-deps --ignore-scripts
           npm rebuild keytar esbuild oxlint
+      - run: node scripts/set-version.mjs "${{ needs.validate-version.outputs.version }}"   # stamp versions from the tag
       - run: npm run build                     # produce packages/plugin/dist for the bundle
       - run: npm install -g clawhub@latest      # an old CLI gets rejected by the hardened server
       - run: clawhub login --token "$CLAWHUB_TOKEN"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -178,3 +178,43 @@ jobs:
         run: |
           echo "Submitted. ClawScan runs server-side."
           echo "Verify manually:  clawhub package moderation-status aquaman-plugin"
+
+  sync-versions:
+    name: Open PR to sync repo versions with the release
+    # Only needs the authoritative registries — a flaky/stuck ClawHub must not
+    # block syncing the repo. If the maintainer already bumped + committed
+    # before tagging, the stamp is a no-op and no PR is opened.
+    needs: [validate-version, npm-publish, pypi-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # push the release-sync branch
+      pull-requests: write      # open the PR (no PAT needed — creating a PR
+                                # doesn't bypass branch protection; merging does)
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main             # base the bump on current main, not the tag
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Stamp versions from the release tag
+        run: node scripts/set-version.mjs "${{ needs.validate-version.outputs.version }}"
+      - name: Open sync PR (skips if repo is already in sync)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.validate-version.outputs.version }}"
+          if git diff --quiet; then
+            echo "main is already at $VERSION — nothing to sync."
+            exit 0
+          fi
+          BRANCH="release-sync/$VERSION"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "release: sync versions to $VERSION"
+          git push -u origin "$BRANCH" --force-with-lease
+          gh pr create --base main --head "$BRANCH" \
+            --title "release: sync versions to $VERSION" \
+            --body "Automated post-publish sync: stamps all version fields to match the released tag \`v$VERSION\`. The published npm/PyPI artifacts already carry this version; merge to keep \`main\` in sync."

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Set every version field across the monorepo to a single value.
+ *
+ * Source of truth for a release is the git tag; CD calls this with the tag
+ * version so the 9 fields the version-gate checks can never drift out of sync.
+ * Also runnable locally before tagging: `npm run set-version 0.13.1`.
+ *
+ * Uses targeted line replacement (not JSON reformatting) to keep diffs minimal,
+ * and fails loudly if any expected field is missing — so a new version field
+ * added to the repo without being added here surfaces immediately.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+([-.][0-9A-Za-z.]+)?$/.test(version)) {
+  console.error(`Usage: set-version <version>\nGot: ${JSON.stringify(version)}`);
+  process.exit(1);
+}
+
+// [file, regex with one capture group for the value, human label]
+const edits = [
+  ['package.json',                        /^(\s*"version":\s*")[^"]*(",)/m,           'root package.json'],
+  ['packages/proxy/package.json',         /^(\s*"version":\s*")[^"]*(",)/m,           'proxy package.json'],
+  ['packages/plugin/package.json',        /^(\s*"version":\s*")[^"]*(",)/m,           'plugin package.json'],
+  ['packages/coder/package.json',         /^(\s*"version":\s*")[^"]*(",)/m,           'coder package.json'],
+  ['packages/plugin/openclaw.plugin.json',/^(\s*"version":\s*")[^"]*(",)/m,           'openclaw.plugin.json'],
+  ['packages/plugin/package.json',        /^(\s*"aquaman-proxy":\s*")[^"]*(",?)/m,    'plugin->aquaman-proxy dep'],
+  ['packages/coder/package.json',         /^(\s*"aquaman-proxy":\s*")[^"]*(",?)/m,    'coder->aquaman-proxy dep'],
+  ['packages/hermes/pyproject.toml',      /^(version\s*=\s*")[^"]*(")/m,              'pyproject.toml'],
+  ['packages/hermes/aquaman_hermes/plugin.yaml', /^(version:\s*")[^"]*(")/m,          'hermes plugin.yaml'],
+];
+
+let failed = false;
+for (const [file, re, label] of edits) {
+  const before = readFileSync(file, 'utf-8');
+  const after = before.replace(re, `$1${version}$2`);
+  if (after === before && !re.test(before)) {
+    console.error(`✗ ${label}: pattern not found in ${file}`);
+    failed = true;
+    continue;
+  }
+  writeFileSync(file, after);
+  console.log(`✓ ${label} = ${version}`);
+}
+if (failed) { console.error('\nOne or more version fields could not be set — aborting.'); process.exit(1); }
+console.log(`\nAll version fields set to ${version}.`);


### PR DESCRIPTION
## Why

The v0.13.1 release **aborted** because none of the 9 version fields were manually bumped (`root package.json = '0.13.0' (expected '0.13.1')` × 9). This makes the **git tag the source of truth** so it can't happen again, while keeping the version checker as a guard.

## What

- **`scripts/set-version.mjs`** — sets all 9 fields (4 `package.json` versions, `openclaw.plugin.json`, both `aquaman-proxy` dep pins, `pyproject.toml`, hermes `plugin.yaml`) from one arg. Minimal line-level diffs; **fails loudly if a field's pattern is missing** (catches a new version field added without updating the script). Local use: `npm run set-version 0.13.1`.
- **`cd.yml` — `validate-version`**: stamps from the tag **then** runs the 9 asserts as a self-guard on the stamper (ordering matters — validation runs *after* set-version, so it verifies the stamper covered every field).
- **`cd.yml` — publish jobs** (npm/pypi/clawhub): each stamps from the tag before build, so published artifacts carry the tag's version.
- **`cd.yml` — `sync-versions`** (new): after npm + PyPI publish, opens a **PR to main** bumping all fields so the repo stays in sync with the release. Uses the default `GITHUB_TOKEN` (no PAT — creating a PR needs no branch-protection bypass; you merge it). Skips silently if main is already in sync (maintainer bumped before tagging). Independent of ClawHub so a stuck publish can't block it.

## Repo setting to enable

The `sync-versions` job needs **Settings → Actions → General → Workflow permissions → 'Allow GitHub Actions to create and approve pull requests'** enabled, or `gh pr create` returns 403.

## Verified

- Script sets all 9 fields; the assert-gate passes against the stamped tree; rejects bad args; accepts prerelease tags.
- No test asserts the package version (the `0.13.0` in Python tests is a self-contained mock), so stamping before `npm test` is safe.
- `cd.yml` valid YAML; lint clean.