### PR TITLE
sec: resolve open CodeQL findings (workflow permissions, ReDoS guard, test exec hygiene, paths-ignore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Typecheck

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          # Tests exercise dummy credentials and spawn the CLI from repo-local
+          # paths by design; none of it ships in the published packages.
+          config: |
+            paths-ignore:
+              - test
+              - packages/hermes/tests
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4
         with:

--- a/packages/proxy/src/openclaw/integration.ts
+++ b/packages/proxy/src/openclaw/integration.ts
@@ -29,6 +29,9 @@ export function parseCalendarVersion(
   version: string | undefined | null
 ): [number, number, number] | null {
   if (!version) return null;
+  // Length guard: the unanchored match below backtracks quadratically on long
+  // digit runs, and no real version string comes anywhere near this bound.
+  if (version.length > 64) return null;
   const m = version.match(/(\d+)\.(\d+)\.(\d+)/);
   if (!m) return null;
   return [Number(m[1]), Number(m[2]), Number(m[3])];

--- a/test/e2e/cli-doctor.test.ts
+++ b/test/e2e/cli-doctor.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { createTempEnv, type TempEnv } from '../helpers/temp-env.js';
@@ -18,7 +18,7 @@ function runDoctor(
   extraEnv: Record<string, string> = {}
 ): { stdout: string; stderr: string; exitCode: number | null } {
   try {
-    const stdout = execSync(`npx tsx ${CLI_PATH} openclaw doctor`, {
+    const stdout = execFileSync('npx', ['tsx', CLI_PATH, 'openclaw', 'doctor'], {
       encoding: 'utf-8',
       env: {
         ...process.env,
@@ -210,7 +210,7 @@ describe('aquaman doctor E2E', () => {
   describe('top-level overview — Hermes integration', () => {
     function runTopDoctor(env: TempEnv, extraEnv: Record<string, string> = {}) {
       try {
-        const stdout = execSync(`npx tsx ${CLI_PATH} doctor`, {
+        const stdout = execFileSync('npx', ['tsx', CLI_PATH, 'doctor'], {
           encoding: 'utf-8',
           env: { ...process.env, ...env.env, ...extraEnv },
           timeout: 20_000,

--- a/test/e2e/cli-policy.test.ts
+++ b/test/e2e/cli-policy.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { createTempEnv, type TempEnv } from '../helpers/temp-env.js';
@@ -16,7 +16,7 @@ function runCli(
   tempEnv: TempEnv,
 ): { stdout: string; stderr: string; exitCode: number | null } {
   try {
-    const stdout = execSync(`npx tsx ${CLI_PATH} ${args}`, {
+    const stdout = execFileSync('npx', ['tsx', CLI_PATH, ...args.split(' ')], {
       encoding: 'utf-8',
       env: {
         ...process.env,


### PR DESCRIPTION
Closes out the 8 actionable open code-scanning alerts; the remaining 11 (`js/clear-text-logging`) are name-heuristic false positives and are being dismissed with per-alert comments instead.

## Changes

- **`actions/missing-workflow-permissions` (alerts #2, #19–#22)** — add a top-level `permissions: contents: read` to `ci.yml`. All five jobs inherit it; CI only checks out code and runs tests, so a read-only `GITHUB_TOKEN` is correct.
- **`js/polynomial-redos` (alert #6)** — `parseCalendarVersion()` matched an unanchored `(\d+)\.(\d+)\.(\d+)` which backtracks quadratically on long digit runs. Added a 64-char length guard before the match; real OpenClaw version strings are ~10 chars.
- **`js/shell-command-injection-from-environment` (alerts #7–#9)** — the e2e helpers in `cli-doctor`/`cli-policy` built shell strings via `execSync(\`npx tsx ${CLI_PATH} …\`)`. Switched to `execFileSync('npx', [...])` with an args array — no shell interpolation, and the tests now tolerate spaces in the checkout path.
- **CodeQL `paths-ignore`** for `test/` and `packages/hermes/tests` — the test suites intentionally exercise dummy credentials (see the six resolved secret-scanning alerts) and spawn the CLI from repo-local paths; none of it ships in the published npm/PyPI packages. This stops the recurring test-fixture noise.

## Not changed (dismissed as false positives)

The 11 `js/clear-text-logging` alerts in `packages/proxy/src/cli/index.ts` all stem from CodeQL's identifier-name heuristic matching the config fields `onePasswordVault`/`onePasswordAccount` (substring "password"). One flags printing the 1Password vault *name* in the biometric-mode hint; the rest flag `console.error(err.message)` after credential-store init failures. Audit of backend throw sites confirms secrets are passed via stdin and never interpolated into error text (`op`/`bw` stderr is surfaced, master passwords are not).

## Verification

- `npm run typecheck` clean
- `test/unit/openclaw/auth-profiles-version.test.ts`, `test/e2e/cli-policy.test.ts`, `test/e2e/cli-doctor.test.ts` — 28/28 pass