### PR TITLE
v0.14.0: host-native credential surfaces (OpenClaw SecretRef + Hermes SecretSource + PostToolUse redaction)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,6 +116,31 @@ jobs:
           npm ci --legacy-peer-deps --ignore-scripts
           npm rebuild keytar esbuild oxlint
       - run: node scripts/set-version.mjs "${{ needs.validate-version.outputs.version }}"   # stamp versions from the tag
+      - name: Pin npm install integrity into plugin metadata
+        # OpenClaw warns when openclaw.install.npmSpec/expectedIntegrity are
+        # missing from a ClawHub package. The npm publish job upstream of this
+        # one has already published the plugin tarball, so its dist.integrity
+        # is authoritative here. Best-effort: registry propagation can lag a
+        # tag push, and the metadata is advisory — never fail the publish on it.
+        run: |
+          export VERSION="${{ needs.validate-version.outputs.version }}"
+          export INTEGRITY=$(npm view "aquaman-plugin@$VERSION" dist.integrity 2>/dev/null || true)
+          if [ -n "$INTEGRITY" ]; then
+            node -e "
+              const fs = require('fs');
+              const p = 'packages/plugin/package.json';
+              const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
+              pkg.openclaw = pkg.openclaw ?? {};
+              pkg.openclaw.install = {
+                npmSpec: 'aquaman-plugin@' + process.env.VERSION,
+                expectedIntegrity: process.env.INTEGRITY,
+              };
+              fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "Pinned openclaw.install: aquaman-plugin@$VERSION ($INTEGRITY)"
+          else
+            echo "::warning::npm view aquaman-plugin@$VERSION dist.integrity returned nothing — publishing without integrity pin"
+          fi
       - run: npm run build                     # produce packages/plugin/dist for the bundle
       - run: npm install -g clawhub@latest      # an old CLI gets rejected by the hardened server
       - run: clawhub login --token "$CLAWHUB_TOKEN"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Three integration paths as of v0.13.0:
 
 1. **OpenClaw Gateway** (`aquaman-plugin`) — original target. Covers LLM providers (Anthropic, OpenAI, Mistral, Hugging Face, xAI, Cloudflare AI Gateway, ElevenLabs) **and** OpenClaw channel credentials (Telegram, Slack, Discord, MS Teams, Matrix, LINE, Twitch, Twilio, etc.). 25 builtin services across 5 auth modes.
 2. **AI coding agents** (`aquaman-coder`, v0.12.0+) — Claude Code today; Codex / OpenCode / Cursor planned. Stops developers from putting plaintext `.env` files into projects just to make their coding agent work. Per-tool-call credential materialization via the `/broker/resolve` UDS endpoint.
-3. **Hermes agent host** (`aquaman-hermes`, v0.13.0+) — Hermes, the #2/co-leader agent host. Hermes is a foreign (Python) host that builds its own HTTP client and exposes no transport hook, so the UDS dispatcher can't be injected. Instead the proxy exposes an **opt-in, token-gated loopback TCP listener** (`127.0.0.1:<port>`, default-off) and Hermes is pointed at it via its native `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL` env vars + a placeholder api_key (= the loopback token). LLM providers only (Anthropic, OpenAI) for now.
+3. **Hermes agent host** (`aquaman-hermes`, v0.13.0+) — Hermes, the #2/co-leader agent host. Hermes is a foreign (Python) host that builds its own HTTP client and exposes no transport hook, so the UDS dispatcher can't be injected. Instead the proxy exposes an **opt-in, token-gated loopback TCP listener** (`127.0.0.1:<port>`, default-off) and Hermes is pointed at it via its native `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL` env vars + a placeholder api_key (= the loopback token). LLM providers: Anthropic + OpenAI. v0.14.0 adds an `aquaman` **secret source** (Hermes ≥ 0.18.1 `ctx.register_secret_source` contract) for project/tool secrets — vault-resolved at startup via the loopback broker; LLM keys stay on the proxy path.
 
 **Target platform:** Unix-like systems (Linux, macOS, WSL2). The OpenClaw Gateway runs as a systemd user service (Linux/WSL2) or LaunchAgent (macOS); the coding-agent path runs alongside the coder's own process.
 
@@ -131,7 +131,18 @@ OpenClaw checks its own auth store (`~/.openclaw/agents/<id>/agent/auth-profiles
 
 **Auth resolution order:** auth-profiles.json → env vars → config file → error
 
-**⚠️ OpenClaw ≥ 2026.6.5 — auth profiles moved to SQLite (openclaw/openclaw#89102, shipped 2026.6.5):** the runtime read path for `auth-profiles.json` was removed; provider auth profiles now live in each agent's `openclaw-agent.sqlite`. The plugin still writes the JSON placeholder at load (it's the import source), but on these versions OpenClaw only ingests it via a one-shot `openclaw doctor --fix`, which then archives the file. `aquaman openclaw doctor` is version-aware (`authProfilesAreSqliteOnly()` in `src/openclaw/integration.ts`) and prints the import step. The plugin's `index.ts` cannot run the import itself — it must not import `child_process` (keeps the OpenClaw security scanner clean). **Holistic fix (SecretRef provider integration manifest, openclaw/openclaw#82326) is deferred to the next plugin touch — see ROADMAP.md.**
+**⚠️ OpenClaw ≥ 2026.6.5 — auth profiles moved to SQLite (openclaw/openclaw#89102, shipped 2026.6.5):** the runtime read path for `auth-profiles.json` was removed; provider auth profiles now live in each agent's `openclaw-agent.sqlite`. The plugin still writes the JSON placeholder at load (it's the import source), but on these versions OpenClaw only ingests it via a one-shot `openclaw doctor --fix`, which then archives the file. `aquaman openclaw doctor` is version-aware (`authProfilesAreSqliteOnly()` in `src/openclaw/integration.ts`) and prints the import step. The plugin's `index.ts` cannot run the import itself — it must not import `child_process` (keeps the OpenClaw security scanner clean). **This whole flow is LEGACY as of v0.14.0 — superseded by the SecretRef integration below on OpenClaw ≥ 2026.6.5; kept only for older gateways.**
+
+### SecretRef provider integration (v0.14.0+, OpenClaw ≥ 2026.6.5)
+
+OpenClaw's canonical credential surface is the **SecretRef** (upstream #82326, shipped 2026-05-29; docs call auth-profiles.json "not a runtime format" and the configure flow scrubs plaintext keys by default). Aquaman adopts it:
+
+- **Manifest** (`openclaw.plugin.json`): `secretProviderIntegrations.aquaman` declares an exec resolver — `command: "${node}"`, `args: ["./dist/secrets-resolver.mjs"]` — plus `nonSecretAuthMarkers: ["aquaman-proxy-managed"]` (effective for bundled-origin plugins only in 2026.6.x; declared for forward compat).
+- **Resolver** (`packages/plugin/secrets-resolver.mjs`, copied to `dist/` at build): speaks exec protocol v1 (request on stdin, `{protocolVersion:1,values:{...}}` on stdout) and returns the **static placeholder** for every id — no vault, no proxy, no env reads. The proxy strips whatever key the gateway presents and injects the real one upstream, so the SecretRef changes how the *placeholder* reaches the gateway, not the isolation boundary. Static-by-design: the gateway resolves its secrets snapshot eagerly at startup, possibly before `aquaman daemon` is up.
+- **Config wiring** (`packages/proxy/src/openclaw/secretref.ts`, applied by `aquaman openclaw setup`, version-gated via `supportsSecretRefIntegrations()` ≥ 2026.6.5; `AQUAMAN_OPENCLAW_VERSION` env overrides detection): writes `secrets.providers.aquaman = { source: "exec", pluginIntegration: { pluginId: "aquaman-plugin", integrationId: "aquaman" } }` and `models.providers.<svc>.apiKey = { source: "exec", provider: "aquaman", id: "<svc>/api_key" }` into `~/.openclaw/openclaw.json`. Config-level refs deliberately (not auth-profile keyRef): runtime-read on every version, no SQLite import step, and they survive OpenClaw's plaintext scrubs. Never clobbers a user-set apiKey; upgrades the legacy literal placeholder in place.
+- On SecretRef-wired installs, setup **skips** generating auth-profiles.json and the plugin's `ensureAuthProfiles()` skips too (`secretRefWiringPresent()` — a plain fs read of openclaw.json, no new imports for the scanner). `aquaman openclaw doctor` reports wiring state: active ✓ / half-migrated ✗ / available → (upgrade hint, not a failure).
+- **2026.7.1+ sentinels (#102009):** SecretRef-backed model creds appear as opaque `oc-sent-v1-...` sentinels everywhere except network egress. Never read credential values back from auth storage/introspection; health checks must not compare key values.
+- Trust gate: secret integrations only load from `bundled`/`global`-origin plugins — `~/.openclaw/extensions/` is `global`, so the standard install location qualifies; workspace-dir dev installs do NOT.
 
 ### Plugin ID Naming
 
@@ -169,7 +180,7 @@ The `aquaman-coder` package extends aquaman to AI coding agents. v0.12.0 ships t
 - `adapters/claude-code/setup.ts` — Writes `~/.claude/settings.json` atomically (mode 0o600, parent dir 0o700). Idempotent via substring-match on the hook command.
 - `cli/index.ts` — Commander-based CLI: `setup <agent>`, `project list/add/remove`, `get <ref>`, `exec <cmd...>`, `hook`, `doctor`.
 
-**Critical hook-protocol notes (re-verified 2026-07-07 against live docs @ Claude Code 2.1.202):** Our contract (`permissionDecision` / `permissionDecisionReason` / `updatedInput` for PreToolUse; `additionalContext` for PostToolUse; exit-2 via stderr) is unchanged and fully supported. Two fields that did NOT exist when the adapter was written now DO (added ~2.1.170+): (1) **`PreToolUse.additionalEnvVars`** — env-var injection. **Deliberately NOT used for credentials**: hook stdout JSON would carry real values through Claude Code's process/memory, which is exactly what the broker + `exec`-wrapper isolation exists to avoid. (2) **`PostToolUse.updatedToolOutput`** — true output rewriting for all tools. Not adopted yet; tracked as a defense-in-depth feature (redact non-Bash tool outputs, e.g. Read/Grep surfacing on-disk secrets). When extending, **verify against the live Claude Code docs**, not training-data memory.
+**Critical hook-protocol notes (re-verified 2026-07-19 against live docs @ Claude Code 2.1.215):** Our contract (`permissionDecision` / `permissionDecisionReason` / `updatedInput` for PreToolUse; `additionalContext` + `updatedToolOutput` for PostToolUse; exit-2 via stderr) is fully supported; no field changes 2.1.203–2.1.215. (1) **`PreToolUse.additionalEnvVars`** — env-var injection. **Deliberately NOT used for credentials**: hook stdout JSON would carry real values through Claude Code's process/memory, which is exactly what the broker + `exec`-wrapper isolation exists to avoid. (2) **`PostToolUse.updatedToolOutput` — ADOPTED in v0.14.0**: `handlePostToolUse` runs the redactor over every tool's output (string via `redact`, structured via `redactDeep`, shape preserved) and rewrites it before it reaches the transcript — covers Read/Grep surfacing on-disk secrets, MCP tools, and unwrapped Bash; the exec wrapper still owns value-based redaction of injected values. Opt-out `AQUAMAN_DISABLE_OUTPUT_REWRITE=1` (pre-2.1.170 hosts) degrades to the warning-only `additionalContext` behavior. (3) Claude Code 2.1.210 fixed exit-2 handling when hook stdout JSON fails schema validation — our hook output is locked down by schema-validity regression tests (`test/unit/coder-hook.test.ts`). When extending, **verify against the live Claude Code docs**, not training-data memory.
 
 **Project map example** (`~/.aquaman/projects.yaml`):
 
@@ -256,8 +267,9 @@ arrives as the provider api_key Hermes sends (`x-api-key` for Anthropic,
 - `packages/proxy/src/daemon.ts` — second `http.Server` on `127.0.0.1:<port>`, gated by
   `isLoopbackTokenValid()` (constant-time). `/_health` exempt. UDS path unchanged.
 - `packages/proxy/src/hermes/config-writer.ts` — generates the `~/.hermes/.env` block
-  (base URLs + placeholder key). Honors `HERMES_HOME` (the var the Hermes CLI itself
-  uses). Idempotent delimited block.
+  (base URLs + placeholder key; v0.14.0+ also always emits `AQUAMAN_LOOPBACK_URL` +
+  `AQUAMAN_LOOPBACK_TOKEN` for the secret source). Honors `HERMES_HOME` (the var the
+  Hermes CLI itself uses). Idempotent delimited block.
 - `packages/proxy/src/hermes/integration.ts` — detect Hermes, configure, write env.
 - `packages/proxy/src/core/types.ts` — `LoopbackConfig` (`enabled`/`port`/`token`/`host`)
   + `HermesConfig`. Config defaults disabled; env overrides `AQUAMAN_LOOPBACK_ENABLED`/
@@ -267,12 +279,33 @@ arrives as the provider api_key Hermes sends (`x-api-key` for Anthropic,
 
 **Hermes >=0.17/0.18 operational notes (verified 2026-07-07 vs hermes-agent 0.18.0):** the base-URL detection, plugin contract, `--version` format, and `HERMES_HOME`/`.env` loading are all compatible — no integration changes needed. Three additions to know: (1) **managed scope** — a root-owned `/etc/hermes/.env` overrides `~/.hermes/.env` AND shell exports; if it pins our env vars the proxy is silently bypassed (`aquaman hermes doctor`/`status` now detect this via `managedScopeShadowedKeys()`); (2) `gateway.multiplex_profiles` (off by default) scopes env per profile — multi-profile users need the aquaman block in each profile's env; (3) Hermes cron jobs pairing `provider: anthropic` with an explicit off-host `base_url` override are refused by its 0.18 exfil guard — jobs inheriting the session runtime (our env-var path) are unaffected.
 
-**Python plugin (`packages/hermes/`, optional sugar):** `aquaman-hermes` on PyPI. A
+**Python plugin (`packages/hermes/`):** `aquaman-hermes` on PyPI. A
 stdlib-only directory plugin (`plugin.yaml` + `register(ctx)`) installed into
 `$HERMES_HOME/plugins/aquaman/` via `aquaman-hermes install`, enabled with
 `hermes plugins enable aquaman`. Adds `/aquaman-status` slash command, `aquaman_status`
-tool, and an `on_session_start` health probe. Holds no credentials; isolation is entirely
-proxy-side. **Do NOT put isolation logic here.**
+tool, and an `on_session_start` health probe. The status/command/hook surface holds no
+credentials; LLM-key isolation is entirely proxy-side. **Do NOT put isolation logic here.**
+
+**Secret source (v0.14.0+, Hermes ≥ 0.18.1):** the plugin also registers an `aquaman`
+`SecretSource` via `ctx.register_secret_source()` (feature-detected with `hasattr`, so
+0.18.0 hosts stay sugar-only). Users bind project/tool secrets in Hermes' config.yaml —
+`secrets.aquaman.env: { GITHUB_TOKEN: aquaman://github/token }` — and the source resolves
+them at Hermes startup through the **token-gated loopback `POST /broker/resolve`**
+(token from `AQUAMAN_LOOPBACK_TOKEN`, written into the `~/.hermes/.env` managed block by
+`aquaman hermes setup` alongside `AQUAMAN_LOOPBACK_URL`). Design rules, all
+conformance-tested (`tests/test_secret_source.py`, `tests/test_compliance.py`):
+- **Two-tier security model, non-negotiable:** LLM provider keys (ANTHROPIC/OPENAI) are
+  REFUSED by the source — they stay on the loopback proxy path (process-isolated
+  placeholder). Project secrets materialize into Hermes' env (same residency as any
+  Hermes secret source — this is NOT process isolation and the docs say so), backed by
+  the user's vault with per-read hash-chained audit instead of a plaintext `.env` line.
+- Contract compliance (`agent/secret_sources/base.py` api v1): `fetch()` never raises,
+  never prompts, never writes `os.environ`; per-ref failures are warnings (one bad ref
+  never sinks the rest); proxy-down/timeout/auth failures are typed fatal errors; Hermes
+  always starts regardless. No disk cache (would defeat residency posture).
+- `protected_env_vars()` covers the token var + wired provider placeholders, so no other
+  secret source can overwrite the loopback wiring; `override_existing` defaults true.
+- Every surfaced error/warning string is scrubbed of the token (`_scrub_secret_text`).
 
 **End-to-end setup:**
 
@@ -488,6 +521,8 @@ Manual smoke-test recipes for the OpenClaw plugin install path, channel auth mod
 | `packages/proxy/src/migration/openclaw-migrator.ts` | Migrates channel + plugin creds from openclaw.json to secure store |
 | `packages/proxy/src/openclaw/env-writer.ts` | Generates env vars for OpenClaw integration |
 | `packages/proxy/src/openclaw/integration.ts` | Detects and launches OpenClaw with env vars |
+| `packages/proxy/src/openclaw/secretref.ts` | SecretRef wiring for openclaw.json (version gate, merge, doctor status; v0.14.0+) |
+| `packages/plugin/secrets-resolver.mjs` | SecretRef exec resolver (protocol v1, static placeholder; shipped as `dist/secrets-resolver.mjs`) |
 | `packages/proxy/src/hermes/config-writer.ts` | Generates `~/.hermes/.env` block (loopback base URLs + placeholder key) |
 | `packages/proxy/src/hermes/integration.ts` | Detects Hermes, configures + writes its env |
 | `packages/hermes/aquaman_hermes/plugin.py` | Hermes Python plugin: register() + status command/tool + health hook |
@@ -508,9 +543,11 @@ Manual smoke-test recipes for the OpenClaw plugin install path, channel auth mod
 | `test/compliance/loopback-listener.test.ts` | Loopback-path compliance (AC-3 token gate, ATLAS T0055/T0090 key isolation, AU-10 audited path) |
 | `test/compliance/cache-residency.test.ts` | Credential-cache compliance (AU-2 audit parity, AC-3 deny-before-cache, SC-28 memory-only, T0055 isolation, IA-5 invalidation) |
 | `test/unit/credentials/caching-store.test.ts` | CachingStore unit tests (TTL, invalidation, no negative caching, error transparency) |
-| `test/unit/hermes/config-writer.test.ts` | Hermes env-writer unit tests (path mapping, HERMES_HOME, idempotent block) |
+| `test/unit/hermes/config-writer.test.ts` | Hermes env-writer unit tests (path mapping, HERMES_HOME, idempotent block, loopback wiring vars) |
+| `test/unit/openclaw-secretref.test.ts` | SecretRef unit tests (version gate, wiring merge/idempotency, resolver exec-protocol spawn tests) |
 | `packages/hermes/tests/test_plugin.py` | Python plugin unit tests (health probe, status text, register wiring) |
-| `packages/hermes/tests/test_compliance.py` | Python plugin compliance (ATLAS T0098 / NIST SI-10/AC-6 — status surface never leaks token/key; reads only `*_BASE_URL`) |
+| `packages/hermes/tests/test_secret_source.py` | Secret source unit tests (fetch paths, error taxonomy, provider-key refusal, real-HTTP broker tests) |
+| `packages/hermes/tests/test_compliance.py` | Python plugin compliance (ATLAS T0098/T0055, NIST SI-10/AC-3/AC-6 — status + secret-source surfaces never leak token/values; isolation not downgradeable) |
 | `test/e2e/keychain-proxy-flow.test.ts` | Real keychain backend E2E (macOS only) |
 | `test/e2e/cli-plugin-mode.test.ts` | CLI startup/output E2E tests |
 | `test/e2e/cli-setup.test.ts` | `aquaman setup` E2E tests |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ openclaw                                          # 3. done - proxy starts autom
 
 Troubleshooting: `openclaw aquaman doctor`.
 
-**Using npm directly?** `npm install -g aquaman-proxy && aquaman openclaw setup` does the same - installs the proxy CLI, stores your keys, installs the plugin into `~/.openclaw/extensions/aquaman-plugin/`, and writes the auth-profiles.json placeholder.
+**Using npm directly?** `npm install -g aquaman-proxy && aquaman openclaw setup` does the same - installs the proxy CLI, stores your keys, installs the plugin into `~/.openclaw/extensions/aquaman-plugin/`, and wires the credentials (SecretRef refs on OpenClaw ≥ 2026.6.5, the auth-profiles.json placeholder on older versions).
 
 The plugin's HTTP interceptor only redirects traffic for services in its `services` config (Anthropic + OpenAI by default). Add more under the plugin config in `openclaw.json` - supported channels include Slack, Discord, Telegram, MS Teams, Matrix, LINE, Twitch, Twilio, BlueBubbles, Mattermost, Nostr, Tlon, Feishu, Google Chat, ElevenLabs, xAI, Cloudflare AI Gateway, Mistral, Hugging Face, and more (25 total).
 

--- a/packages/coder/src/adapters/claude-code/hook.ts
+++ b/packages/coder/src/adapters/claude-code/hook.ts
@@ -13,17 +13,23 @@
  * `updatedInput.command` to invoke it under `aquaman-coder exec`,
  * which runs the broker resolve + redaction pipeline server-side.
  *
- * PostToolUse hookSpecificOutput only supports `additionalContext` and
- * cannot mutate the tool output (the tool has already run). When the
- * redactor finds secrets we emit a warning notice via additionalContext
- * — the actual scrubbing must happen inside `aquaman-coder exec` itself
- * so leaked secrets never reach the model.
+ * PostToolUse hookSpecificOutput supports `additionalContext` and — since
+ * Claude Code ~2.1.170 (verified stable through 2.1.215, 2026-07-19) —
+ * `updatedToolOutput`, which rewrites the tool output before it reaches
+ * the transcript. We run the redactor over every tool's output (Read /
+ * Grep / Glob surfacing on-disk secrets, unwrapped Bash, MCP tools) and
+ * rewrite in place. This is defense-in-depth on top of `aquaman-coder
+ * exec`'s stdout/stderr scrubbing: the exec wrapper knows the literal
+ * injected values (value-based redaction), the hook covers shape-based
+ * patterns for outputs that never passed through the wrapper. Set
+ * AQUAMAN_DISABLE_OUTPUT_REWRITE=1 to fall back to warning-only on
+ * pre-2.1.170 Claude Code versions that don't know the field.
  */
 
 // Note: imported from `aquaman-proxy` (which re-exports from its
 // merged core/). There is no separate `aquaman-core` npm package since
 // v0.7.0; the vitest alias resolves the same path for tests.
-import { redact } from 'aquaman-proxy';
+import { redact, redactDeep } from 'aquaman-proxy';
 import { findProjectForCwd, loadProjects } from '../../projects.js';
 import { BrokerClient } from '../../broker-client.js';
 
@@ -51,6 +57,12 @@ export interface HookContext {
    * `aquaman-coder exec --` — change in tests to assert the rewrite.
    */
   wrapperPrefix?: string;
+  /**
+   * Disable PostToolUse `updatedToolOutput` rewriting (fall back to the
+   * warning-only additionalContext behavior for Claude Code < 2.1.170).
+   * Defaults to the AQUAMAN_DISABLE_OUTPUT_REWRITE env var.
+   */
+  disableOutputRewrite?: boolean;
 }
 
 // Default wrapper uses the direct binary form (`aquaman-coder exec`) rather
@@ -124,28 +136,56 @@ export async function handlePreToolUse(
 }
 
 /**
- * Inspect tool output for leaked secrets. Cannot rewrite — the tool has
- * already run — but we surface a warning to Claude via additionalContext.
- * Pair with `aquaman-coder exec`'s stdout/stderr redactor for real
- * prevention.
+ * Inspect tool output for leaked secrets and rewrite it via
+ * `updatedToolOutput` (Claude Code ≥2.1.170) so redacted markers — not
+ * the secrets — reach the transcript. Applies to every tool: Read/Grep
+ * surfacing on-disk secrets, MCP tools, and Bash commands that didn't
+ * route through the exec wrapper. String outputs stay strings; structured
+ * outputs are deep-redacted with their shape preserved.
+ *
+ * With rewriting disabled (AQUAMAN_DISABLE_OUTPUT_REWRITE=1, for
+ * pre-2.1.170 hosts) this degrades to the historical warning-only
+ * additionalContext behavior.
  */
-export function handlePostToolUse(event: HookEvent): HookDecision | null {
+export function handlePostToolUse(
+  event: HookEvent,
+  ctx: HookContext = {}
+): HookDecision | null {
   const out = (event as any).tool_response ?? (event as any).tool_output;
   if (out === undefined || out === null) return null;
 
-  const text = typeof out === 'string' ? out : JSON.stringify(out);
-  const { findings } = redact(text);
+  const rewriteEnabled = !(
+    ctx.disableOutputRewrite ??
+    process.env.AQUAMAN_DISABLE_OUTPUT_REWRITE === '1'
+  );
+
+  const { output, findings } =
+    typeof out === 'string' ? redact(out) : redactDeep(out);
   if (findings.length === 0) return null;
 
   const summary = findings.map((f) => `${f.kind}×${f.count}`).join(', ');
+
+  if (!rewriteEnabled) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext:
+          `aquaman: tool output contained secret patterns (${summary}). ` +
+          `These were detected after the fact — to scrub before output ` +
+          `reaches the model, ensure agent-invoked commands route through ` +
+          `\`aquaman-coder exec\`.`,
+      },
+    };
+  }
+
   return {
     hookSpecificOutput: {
       hookEventName: 'PostToolUse',
+      updatedToolOutput: output,
       additionalContext:
-        `aquaman: tool output contained secret patterns (${summary}). ` +
-        `These were detected after the fact — to scrub before output ` +
-        `reaches the model, ensure agent-invoked commands route through ` +
-        `\`aquaman-coder exec\`.`,
+        `aquaman: redacted secret patterns from this tool's output ` +
+        `(${summary}) before it reached the transcript. The underlying ` +
+        `data still exists at its source — treat it as sensitive.`,
     },
   };
 }
@@ -178,7 +218,7 @@ export async function runHookFromStdin(
         decision = await handlePreToolUse(event, ctx);
         break;
       case 'PostToolUse':
-        decision = handlePostToolUse(event);
+        decision = handlePostToolUse(event, ctx);
         break;
       default:
         return 0;

--- a/packages/hermes/README.md
+++ b/packages/hermes/README.md
@@ -15,6 +15,9 @@ the real credential. This plugin adds:
 - **`/aquaman-status`**: slash command showing proxy reachability + wiring.
 - **`aquaman_status`**: an agent-facing tool with the same info.
 - **`on_session_start`**: a one-shot health probe that warns if the proxy is down.
+- **`aquaman` secret source** (Hermes ≥ 0.18.1): resolves project/tool secrets —
+  GitHub tokens, database URLs, anything under `secrets.aquaman.env` — from your
+  vault at startup, through the proxy's token-gated broker. See below.
 
 ## How it works
 
@@ -57,6 +60,35 @@ hermes                            # then run: /aquaman-status
 `aquaman-hermes install` honors `HERMES_HOME` (the same var the Hermes CLI uses to
 relocate its config dir); it defaults to `~/.hermes`.
 
+## Project secrets (secret source, Hermes ≥ 0.18.1)
+
+LLM keys are only half the problem — agents also need GitHub tokens, database URLs,
+and other project secrets that usually end up in a plaintext `.env`. On Hermes ≥
+0.18.1 this plugin registers an `aquaman` secret source so those come from your
+vault instead. Bind them in `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  aquaman:
+    enabled: true
+    env:
+      GITHUB_TOKEN: aquaman://github/token
+      DATABASE_URL: aquaman://supabase/db_url
+```
+
+At startup the source resolves each binding through the proxy's token-gated
+loopback broker (per-read, hash-chain audited) and hands the values to Hermes'
+secret orchestrator. Notes on the security model:
+
+- **LLM provider keys are refused.** `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` bindings
+  are rejected with a warning — those stay on the loopback proxy path, where the real
+  key never enters the Hermes process at all.
+- Project secrets resolved this way **do** live in Hermes' process env (that's what a
+  Hermes secret source is). What you gain over a `.env` line: vault-at-rest storage,
+  per-read tamper-evident audit, instant rotation, and no plaintext files on disk.
+- Fail-open by design: if the proxy is down, Hermes still starts (with a warning).
+- One bad ref never blocks the others; errors/warnings never contain the token.
+
 ## Uninstall
 
 ```bash
@@ -66,11 +98,12 @@ aquaman-hermes uninstall
 
 ## Notes
 
-- The plugin holds no credentials and makes no privileged calls. It only reads the
-  provider base-URL env vars and probes the proxy's token-exempt `/_health` endpoint.
+- The status/command/hook surface holds no credentials — it only reads the provider
+  base-URL env vars and probes the proxy's token-exempt `/_health` endpoint. The
+  secret source transits credentials only while handing them to Hermes' orchestrator.
 - It depends only on the Python standard library.
-- Only LLM providers (Anthropic, OpenAI) are wired today. Channels/other providers are
-  out of scope for the Hermes path (no base-URL lever to redirect them).
+- LLM providers wired via base-URL: Anthropic + OpenAI. Channels are out of scope for
+  the Hermes path (no base-URL lever); project secrets go through the secret source.
 - Hermes >=0.17 "managed scope": a root-owned `/etc/hermes/.env` overrides
   `~/.hermes/.env` — if an admin pins the `ANTHROPIC_*`/`OPENAI_*` vars there, the
   proxy is bypassed. `aquaman hermes doctor` detects and flags this.

--- a/packages/hermes/aquaman_hermes/plugin.py
+++ b/packages/hermes/aquaman_hermes/plugin.py
@@ -6,10 +6,27 @@ Registers:
   * ``on_session_start`` hook — one-shot health probe; logs a warning if the
     aquaman loopback proxy isn't reachable (so a misconfigured session is
     obvious instead of silently falling back to direct provider calls).
+  * ``aquaman`` secret source (Hermes >= 0.18.1, feature-detected via
+    ``hasattr(ctx, "register_secret_source")``) — resolves explicit
+    ``ENV_VAR: aquaman://service/key`` bindings from ``secrets.aquaman.env``
+    in Hermes' config.yaml through the proxy's token-gated loopback
+    ``/broker/resolve`` endpoint.
 
-The plugin holds no credentials and makes no privileged calls. It only reads the
-provider base-URL env vars that aquaman wrote into ``~/.hermes/.env`` and probes
-the proxy's ``/_health`` endpoint (which is exempt from the loopback token).
+Security model split (deliberate — keep it this way):
+  * **LLM provider keys** (ANTHROPIC_API_KEY / OPENAI_API_KEY) flow through the
+    loopback *proxy* path: Hermes holds only a placeholder, the proxy injects
+    the real key upstream. Process-isolated. The secret source REFUSES to
+    resolve bindings for these vars so the isolation can't be accidentally
+    (or maliciously, via a poisoned config.yaml) downgraded.
+  * **Project/tool secrets** (GitHub tokens, DB URLs, ...) have no base-URL
+    lever in Hermes, so the secret source materializes them into Hermes'
+    process env at startup — same residency as any Hermes secret source
+    (this is NOT process isolation, and the docs say so), but backed by the
+    user's own vault with per-read hash-chained audit instead of a plaintext
+    ``.env`` line.
+
+The command/tool/hook surface holds no credentials. The secret source holds
+them only transiently while handing them to Hermes' orchestrator.
 """
 
 from __future__ import annotations
@@ -17,6 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional, Tuple
@@ -123,6 +141,253 @@ def _on_session_start(**_: Any) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Secret source (Hermes >= 0.18.1 — agent.secret_sources contract, api v1)
+# ---------------------------------------------------------------------------
+
+# Same grammar as aquaman-coder's projects.yaml refs and the proxy's
+# SAFE_SERVICE_NAME / key validation in daemon.ts.
+_AQUAMAN_REF_RE = re.compile(
+    r"^aquaman://(?P<service>[a-z0-9][a-z0-9._-]*)/(?P<key>[a-zA-Z0-9][a-zA-Z0-9._-]*)$"
+)
+_DEFAULT_TOKEN_ENV = "AQUAMAN_LOOPBACK_TOKEN"
+_DEFAULT_LOOPBACK_URL = "http://127.0.0.1:8585"
+_DEFAULT_REQUEST_TIMEOUT = 5.0
+
+# LLM provider keys stay on the loopback-proxy path (placeholder in Hermes'
+# env, real key injected proxy-side — process isolation). The secret source
+# refuses to resolve bindings for them so a config.yaml edit can't silently
+# downgrade the isolation to env materialization.
+_PROXY_ISOLATED_VARS: Dict[str, str] = {
+    "ANTHROPIC_API_KEY": "ANTHROPIC_BASE_URL",
+    "OPENAI_API_KEY": "OPENAI_BASE_URL",
+}
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def _wired_placeholder_vars() -> "frozenset[str]":
+    """Provider api-key vars currently wired as loopback placeholders.
+
+    A provider key var is a placeholder (not a real credential) exactly when
+    its base-URL var points at a loopback host — i.e. aquaman's proxy path is
+    active for that provider. Those vars must not be overwritten by ANY secret
+    source: a real key there would leak into Hermes' env AND break the
+    proxy's token gate (the placeholder IS the loopback token).
+    """
+    wired = set()
+    for key_var, url_var in _PROXY_ISOLATED_VARS.items():
+        parsed = urlparse(os.environ.get(url_var) or "")
+        if parsed.hostname in _LOOPBACK_HOSTS:
+            wired.add(key_var)
+    return frozenset(wired)
+
+
+def _scrub_secret_text(text: str, cfg: Optional[dict] = None) -> str:
+    """Remove the loopback token from text destined for Hermes' startup log.
+
+    Error/warning strings in a FetchResult are logged by Hermes at startup —
+    they must never carry the token, even when an unexpected exception message
+    embeds it (urllib errors can echo request headers).
+    """
+    names = {_DEFAULT_TOKEN_ENV}
+    if isinstance(cfg, dict) and cfg.get("token_env"):
+        names.add(str(cfg["token_env"]))
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            text = text.replace(value, "[REDACTED:loopback-token]")
+    return text
+
+
+def _broker_resolve_http(
+    origin: str, token: str, service: str, key: str, timeout: float
+) -> Tuple[Optional[str], Optional[str], Optional[int]]:
+    """POST /broker/resolve on the loopback listener.
+
+    Returns ``(value, error, http_status)`` — exactly one of value/error is
+    set. Module-level so tests can monkeypatch it. Never raises for HTTP-level
+    failures; lets URLError/timeout propagate for the caller to classify.
+    """
+    payload = json.dumps({"service": service, "key": key}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{origin}/broker/resolve",
+        data=payload,
+        headers={"content-type": "application/json", "x-aquaman-token": token},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (loopback only)
+            body = json.loads(resp.read().decode("utf-8"))
+            return body.get("value"), None, resp.status
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = json.loads(exc.read().decode("utf-8"))
+            message = detail.get("error") or f"HTTP {exc.code}"
+            if detail.get("fix"):
+                message += f" (fix: {detail['fix']})"
+        except Exception:
+            message = f"HTTP {exc.code}"
+        return None, message, exc.code
+
+
+def build_secret_source():
+    """Construct the ``aquaman`` SecretSource instance, or None.
+
+    Returns None when the host has no secret-source contract (Hermes <
+    0.18.1) or the import shape drifted — callers treat None as "sugar-only
+    mode", never an error.
+    """
+    try:
+        from agent.secret_sources.base import (  # type: ignore[import-not-found]
+            ErrorKind,
+            FetchResult,
+            SecretSource,
+            is_valid_env_name,
+        )
+    except Exception:
+        return None
+
+    class AquamanSource(SecretSource):
+        """Mapped source: explicit ENV_VAR → aquaman://service/key bindings.
+
+        Contract compliance (agent/secret_sources/base.py, api v1):
+        fetch() never raises, never prompts, never writes os.environ —
+        it returns what it WOULD contribute and the orchestrator applies.
+        No disk cache: the proxy is local and fast, and caching resolved
+        values to disk would defeat aquaman's residency posture.
+        """
+
+        api_version = 1
+        name = "aquaman"
+        label = "Aquaman Proxy"
+        shape = "mapped"
+        scheme = "aquaman"
+
+        def override_existing(self, cfg: dict) -> bool:
+            # Mirror the built-in 1Password source: an explicit
+            # VAR→aquaman:// binding is the strongest user intent there is.
+            return bool(isinstance(cfg, dict) and cfg.get("override_existing", True))
+
+        def protected_env_vars(self, cfg: dict):
+            token_env = _DEFAULT_TOKEN_ENV
+            if isinstance(cfg, dict):
+                token_env = str(cfg.get("token_env") or token_env)
+            return frozenset({token_env}) | _wired_placeholder_vars()
+
+        def fetch(self, cfg: dict, home_path) -> "FetchResult":
+            cfg = cfg if isinstance(cfg, dict) else {}
+            try:
+                result = self._fetch(cfg)
+            except Exception as exc:  # contract: never raise
+                result = FetchResult(
+                    error=f"aquaman source internal error: {exc}",
+                    error_kind=ErrorKind.INTERNAL,
+                )
+            # Startup-log hygiene: whatever we surface, the token stays out.
+            if result.error:
+                result.error = _scrub_secret_text(result.error, cfg)
+            result.warnings = [_scrub_secret_text(w, cfg) for w in result.warnings]
+            return result
+
+        def _fetch(self, cfg: dict) -> "FetchResult":
+            env_map = cfg.get("env")
+            if not isinstance(env_map, dict) or not env_map:
+                return FetchResult(
+                    error="no env bindings configured — add secrets.aquaman.env "
+                          "{ENV_VAR: aquaman://service/key} to config.yaml",
+                    error_kind=ErrorKind.NOT_CONFIGURED,
+                )
+
+            token_env = str(cfg.get("token_env") or _DEFAULT_TOKEN_ENV)
+            token = os.environ.get(token_env)
+            if not token:
+                return FetchResult(
+                    error=f"{token_env} is not set — run: aquaman hermes setup "
+                          "(writes the loopback token into ~/.hermes/.env)",
+                    error_kind=ErrorKind.NOT_CONFIGURED,
+                )
+
+            origin = str(
+                cfg.get("base_url")
+                or os.environ.get("AQUAMAN_LOOPBACK_URL")
+                or _loopback_origin()
+                or _DEFAULT_LOOPBACK_URL
+            ).rstrip("/")
+            timeout = float(cfg.get("request_timeout_seconds") or _DEFAULT_REQUEST_TIMEOUT)
+
+            secrets: Dict[str, str] = {}
+            warnings = []
+            for var, ref in sorted(env_map.items()):
+                var = str(var)
+                if not is_valid_env_name(var):
+                    warnings.append(f"invalid env var name {var!r} — skipped")
+                    continue
+                if var in _PROXY_ISOLATED_VARS:
+                    warnings.append(
+                        f"{var} is refused by the aquaman source: LLM provider keys "
+                        "stay process-isolated on the loopback proxy path (the "
+                        f"placeholder in ~/.hermes/.env). Remove the {var} binding "
+                        "from secrets.aquaman.env."
+                    )
+                    continue
+                match = _AQUAMAN_REF_RE.match(str(ref))
+                if not match:
+                    warnings.append(
+                        f"{var}: invalid ref {ref!r} (expected aquaman://service/key) — skipped"
+                    )
+                    continue
+
+                service, key = match.group("service"), match.group("key")
+                try:
+                    value, error, status = _broker_resolve_http(origin, token, service, key, timeout)
+                except urllib.error.URLError as exc:
+                    reason = getattr(exc, "reason", exc)
+                    if isinstance(reason, TimeoutError) or isinstance(exc, TimeoutError):
+                        return FetchResult(
+                            secrets=secrets, warnings=warnings,
+                            error=f"aquaman proxy timed out at {origin}",
+                            error_kind=ErrorKind.TIMEOUT,
+                        )
+                    # Proxy down means every remaining ref fails identically —
+                    # abort instead of warning N times.
+                    return FetchResult(
+                        secrets=secrets, warnings=warnings,
+                        error=f"aquaman proxy not reachable at {origin} ({reason}) — "
+                              "start it with: aquaman daemon",
+                        error_kind=ErrorKind.NETWORK,
+                    )
+                except TimeoutError:
+                    return FetchResult(
+                        secrets=secrets, warnings=warnings,
+                        error=f"aquaman proxy timed out at {origin}",
+                        error_kind=ErrorKind.TIMEOUT,
+                    )
+
+                if error is not None:
+                    if status in (401, 403):
+                        return FetchResult(
+                            secrets=secrets, warnings=warnings,
+                            error=f"aquaman loopback token rejected ({error}) — "
+                                  "re-run: aquaman hermes setup",
+                            error_kind=ErrorKind.AUTH_FAILED,
+                        )
+                    # 404 / 400 / 500 are per-ref problems: one bad ref never
+                    # sinks the rest (mirrors the built-in 1Password source).
+                    warnings.append(f"{var} ({service}/{key}): {error}")
+                    continue
+                if not value:
+                    warnings.append(
+                        f"{var} ({service}/{key}): resolved to an empty value — skipped "
+                        "(applying it would clobber a good .env/shell credential)"
+                    )
+                    continue
+                secrets[var] = value
+
+            return FetchResult(secrets=secrets, warnings=warnings)
+
+    return AquamanSource()
+
+
 _TOOL_SCHEMA = {
     "type": "object",
     "properties": {},
@@ -150,4 +415,18 @@ def register(ctx) -> None:
     except Exception as exc:  # pragma: no cover - tool registry API drift safety
         logger.debug("aquaman: tool registration skipped (%s)", exc)
     ctx.register_hook("on_session_start", _on_session_start)
+
+    # Hermes >= 0.18.1: register aquaman as a secret source for project/tool
+    # secrets. Feature-detected (hasattr is the documented probe); on older
+    # hosts the plugin stays sugar-only. Registration failures are logged and
+    # swallowed — the secret source must never break plugin load.
+    if hasattr(ctx, "register_secret_source"):
+        source = build_secret_source()
+        if source is not None:
+            try:
+                ctx.register_secret_source(source)
+                logger.debug("aquaman secret source registered")
+            except Exception as exc:  # pragma: no cover - registry API drift safety
+                logger.debug("aquaman: secret-source registration skipped (%s)", exc)
+
     logger.debug("aquaman plugin registered (command + tool + on_session_start)")

--- a/packages/hermes/aquaman_hermes/plugin.yaml
+++ b/packages/hermes/aquaman_hermes/plugin.yaml
@@ -1,6 +1,6 @@
 name: aquaman
 version: "0.13.1"
-description: "Credential isolation for Hermes. API keys live in a secure backend (Keychain, 1Password, Vault, Bitwarden, KeePassXC, encrypted-file, systemd-creds) and are injected by the aquaman proxy's loopback listener — they never enter the Hermes process. This plugin adds an /aquaman-status slash command, an aquaman_status tool, and an on_session_start health check; the isolation itself is done by the proxy + the ANTHROPIC_BASE_URL/OPENAI_BASE_URL env vars in ~/.hermes/.env."
+description: "Credential isolation for Hermes. API keys live in a secure backend (Keychain, 1Password, Vault, Bitwarden, KeePassXC, encrypted-file, systemd-creds) and are injected by the aquaman proxy's loopback listener — they never enter the Hermes process. This plugin adds an /aquaman-status slash command, an aquaman_status tool, an on_session_start health check, and (Hermes >= 0.18.1) an `aquaman` secret source that resolves project/tool secrets (secrets.aquaman.env bindings like GITHUB_TOKEN: aquaman://github/token) from your vault via the proxy's token-gated broker. LLM provider keys stay on the loopback path (process-isolated); the secret source refuses to materialize them."
 author: "tech4242"
 hooks:
   - on_session_start

--- a/packages/hermes/tests/conftest.py
+++ b/packages/hermes/tests/conftest.py
@@ -1,0 +1,75 @@
+"""Shared fixtures: a faithful fake of the Hermes >= 0.18.1 secret-source
+contract (shapes copied from hermes-agent v2026.7.7.2
+``agent/secret_sources/base.py``, api v1), injected into sys.modules so the
+suite stays stdlib-only with no Hermes install."""
+
+import re
+import sys
+import types
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pytest
+
+
+def install_fake_hermes_base(monkeypatch):
+    class ErrorKind(str, Enum):
+        NOT_CONFIGURED = "not_configured"
+        BINARY_MISSING = "binary_missing"
+        AUTH_FAILED = "auth_failed"
+        AUTH_EXPIRED = "auth_expired"
+        REF_INVALID = "ref_invalid"
+        NETWORK = "network"
+        EMPTY_VALUE = "empty_value"
+        TIMEOUT = "timeout"
+        INTERNAL = "internal"
+
+    @dataclass
+    class FetchResult:
+        secrets: Dict[str, str] = field(default_factory=dict)
+        applied: List[str] = field(default_factory=list)
+        skipped: List[str] = field(default_factory=list)
+        warnings: List[str] = field(default_factory=list)
+        error: Optional[str] = None
+        error_kind: Optional[ErrorKind] = None
+        binary_path: Optional[Path] = None
+
+        @property
+        def ok(self):
+            return self.error is None
+
+    class SecretSource:
+        api_version = 1
+        name = ""
+        label = ""
+        shape = "mapped"
+        scheme = None
+
+        def fetch(self, cfg, home_path):  # pragma: no cover - abstract stand-in
+            raise NotImplementedError
+
+    _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    def is_valid_env_name(name):
+        return bool(name) and bool(_ENV_NAME_RE.match(name))
+
+    base = types.ModuleType("agent.secret_sources.base")
+    base.ErrorKind = ErrorKind
+    base.FetchResult = FetchResult
+    base.SecretSource = SecretSource
+    base.is_valid_env_name = is_valid_env_name
+    base.SECRET_SOURCE_API_VERSION = 1
+
+    agent_pkg = types.ModuleType("agent")
+    sources_pkg = types.ModuleType("agent.secret_sources")
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.secret_sources", sources_pkg)
+    monkeypatch.setitem(sys.modules, "agent.secret_sources.base", base)
+    return base
+
+
+@pytest.fixture()
+def hermes_base(monkeypatch):
+    return install_fake_hermes_base(monkeypatch)

--- a/packages/hermes/tests/test_compliance.py
+++ b/packages/hermes/tests/test_compliance.py
@@ -1,12 +1,13 @@
 """Compliance tests for the aquaman-hermes plugin (stdlib only).
 
-The plugin is a credential-free, in-session "sugar" layer: it reads the
-provider ``*_BASE_URL`` env vars aquaman wrote and probes ``/_health``. It holds
-no credentials and performs no isolation — that is entirely proxy-side. These
-tests therefore assert the controls that ARE applicable to such a layer: that it
-does not *undermine* the isolation the proxy enforces.
+The command/tool/hook surface is a credential-free, in-session "sugar" layer:
+it reads the provider ``*_BASE_URL`` env vars aquaman wrote and probes
+``/_health``. It holds no credentials and performs no isolation — that is
+entirely proxy-side. The secret source (Hermes >= 0.18.1) DOES transit
+credentials — from the token-gated broker to Hermes' orchestrator — so it gets
+its own control set below.
 
-Mapped controls:
+Mapped controls (status surface):
   - MITRE ATLAS AML.T0098 (AI Agent Tool Credential Harvesting): the agent-facing
     ``aquaman_status`` tool and ``/aquaman-status`` command must never surface the
     loopback token or any API-key value, even when both are present in the env.
@@ -15,6 +16,17 @@ Mapped controls:
     health probe targets the token-exempt ``/_health`` and transmits no credential.
   - NIST SP 800-53 AC-6 (Least Privilege): the plugin consults only ``*_BASE_URL``
     env vars, never ``*_API_KEY`` — it has no need for, and no access to, the key.
+
+Mapped controls (secret source):
+  - MITRE ATLAS AML.T0055 (Unsecured Credentials): the source refuses to
+    materialize LLM provider keys into Hermes' process env — a poisoned
+    config.yaml cannot downgrade the loopback isolation to env residency.
+  - NIST SP 800-53 AC-3 (Access Enforcement): every broker resolve carries the
+    loopback token; there is no unauthenticated resolve path.
+  - NIST SP 800-53 SI-10: error/warning strings handed to Hermes (which logs
+    them at startup) never contain the token or any resolved secret value.
+  - NIST SP 800-53 AC-6: protected_env_vars() prevents any other secret source
+    from overwriting the wiring vars (token + wired provider placeholders).
 """
 
 from __future__ import annotations
@@ -150,3 +162,87 @@ def test_si10_session_start_hook_does_not_log_the_token(monkeypatch, caplog):
     with caplog.at_level("DEBUG", logger="aquaman_hermes"):
         plugin._on_session_start()
     assert SECRET_TOKEN not in caplog.text
+
+
+# --- Secret source (Hermes >= 0.18.1) ----------------------------------------
+
+def _source_cfg(env):
+    return {"enabled": True, "env": env}
+
+
+def test_t0055_source_refuses_llm_provider_key_materialization(hermes_base, monkeypatch):
+    # A poisoned (or merely misguided) config.yaml binding ANTHROPIC_API_KEY /
+    # OPENAI_API_KEY through the source must NOT pull the real provider key
+    # into Hermes' process env — the loopback proxy path is the only route.
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", SECRET_TOKEN)
+    real_key = "sk-ant-REAL-KEY-MUST-NOT-MATERIALIZE"
+    monkeypatch.setattr(
+        plugin, "_broker_resolve_http",
+        lambda origin, token, service, key, timeout: (real_key, None, 200),
+    )
+    source = plugin.build_secret_source()
+    result = source.fetch(_source_cfg({
+        "ANTHROPIC_API_KEY": "aquaman://anthropic/api_key",
+        "OPENAI_API_KEY": "aquaman://openai/api_key",
+    }), None)
+    assert result.ok
+    assert result.secrets == {}
+    assert real_key not in str(result.warnings)
+
+
+def test_ac3_every_resolve_carries_the_loopback_token(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", SECRET_TOKEN)
+    seen_tokens = []
+
+    def record(origin, token, service, key, timeout):
+        seen_tokens.append(token)
+        return "value", None, 200
+
+    monkeypatch.setattr(plugin, "_broker_resolve_http", record)
+    source = plugin.build_secret_source()
+    result = source.fetch(_source_cfg({
+        "A": "aquaman://svc/one", "B": "aquaman://svc/two",
+    }), None)
+    assert result.ok
+    assert seen_tokens == [SECRET_TOKEN, SECRET_TOKEN]
+
+
+def test_si10_source_errors_and_warnings_never_contain_the_token(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", SECRET_TOKEN)
+    scenarios = [
+        # auth rejected (401) — fatal error path
+        lambda o, t, s, k, tm: (None, "Loopback request rejected", 401),
+        # missing credential (404) — per-ref warning path
+        lambda o, t, s, k, tm: (None, "No credential found", 404),
+        # unexpected exception — INTERNAL path
+        lambda o, t, s, k, tm: (_ for _ in ()).throw(ValueError("boom " + t)),
+    ]
+    source = plugin.build_secret_source()
+    for stub in scenarios:
+        monkeypatch.setattr(plugin, "_broker_resolve_http", stub)
+        result = source.fetch(_source_cfg({"X": "aquaman://svc/key"}), None)
+        surfaced = " ".join([result.error or ""] + list(result.warnings))
+        assert SECRET_TOKEN not in surfaced
+
+
+def test_si10_source_warnings_never_contain_resolved_values(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", SECRET_TOKEN)
+    secret_value = "ghp_RESOLVED_SECRET_VALUE"
+    monkeypatch.setattr(
+        plugin, "_broker_resolve_http",
+        lambda o, t, s, k, tm: (secret_value, None, 200),
+    )
+    source = plugin.build_secret_source()
+    result = source.fetch(_source_cfg({"GOOD": "aquaman://svc/key", "BAD REF": "junk"}), None)
+    assert result.secrets == {"GOOD": secret_value}
+    assert secret_value not in " ".join(result.warnings)
+
+
+def test_ac6_protected_vars_cover_token_and_wired_placeholders(hermes_base, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:8585/anthropic")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:8585/openai/v1")
+    source = plugin.build_secret_source()
+    protected = source.protected_env_vars({})
+    # No other secret source may overwrite the loopback wiring: the token, and
+    # the provider placeholders that ARE the token on wired providers.
+    assert {"AQUAMAN_LOOPBACK_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"} <= protected

--- a/packages/hermes/tests/test_secret_source.py
+++ b/packages/hermes/tests/test_secret_source.py
@@ -1,0 +1,354 @@
+"""Unit tests for the aquaman Hermes secret source (Hermes >= 0.18.1 contract).
+
+The real `agent.secret_sources.base` lives inside a Hermes install; these
+tests inject a faithful fake (shapes copied from hermes-agent v2026.7.7.2
+`agent/secret_sources/base.py`, api v1) into sys.modules so the tests run
+stdlib-only, exactly like the rest of this suite.
+"""
+
+import json
+import threading
+import urllib.error
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from aquaman_hermes import plugin
+
+
+# The fake `agent.secret_sources.base` module (Hermes >= 0.18.1 contract)
+# comes from conftest.py's `hermes_base` fixture.
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "ANTHROPIC_BASE_URL", "OPENAI_BASE_URL",
+        "AQUAMAN_LOOPBACK_URL", "AQUAMAN_LOOPBACK_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+TOKEN = "aqm_lb_" + "e" * 48
+
+
+def _cfg(env=None, **extra):
+    cfg = {"enabled": True, "env": env or {}}
+    cfg.update(extra)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Availability / registration
+# ---------------------------------------------------------------------------
+
+def test_build_returns_none_without_hermes_contract():
+    # No agent.secret_sources.base importable (pre-0.18.1 host) → sugar-only.
+    assert plugin.build_secret_source() is None
+
+
+def test_build_returns_source_with_contract(hermes_base):
+    source = plugin.build_secret_source()
+    assert source is not None
+    assert source.name == "aquaman"
+    assert source.scheme == "aquaman"
+    assert source.shape == "mapped"
+    assert source.api_version == 1
+
+
+def test_register_feature_detects_secret_source(hermes_base):
+    class Ctx:
+        def __init__(self):
+            self.commands = {}
+            self.tools = {}
+            self.hooks = {}
+            self.sources = []
+
+        def register_command(self, name, handler, **kw):
+            self.commands[name] = handler
+
+        def register_tool(self, name, toolset, schema, handler, **kw):
+            self.tools[name] = handler
+
+        def register_hook(self, name, cb):
+            self.hooks[name] = cb
+
+        def register_secret_source(self, source):
+            self.sources.append(source)
+
+    ctx = Ctx()
+    plugin.register(ctx)
+    assert len(ctx.sources) == 1
+    assert ctx.sources[0].name == "aquaman"
+
+
+def test_register_on_old_host_without_secret_sources():
+    class OldCtx:
+        def register_command(self, name, handler, **kw):
+            pass
+
+        def register_tool(self, name, toolset, schema, handler, **kw):
+            pass
+
+        def register_hook(self, name, cb):
+            pass
+
+    # No register_secret_source attr and no hermes modules — must not raise.
+    plugin.register(OldCtx())
+
+
+# ---------------------------------------------------------------------------
+# fetch() behavior (broker HTTP stubbed at the module seam)
+# ---------------------------------------------------------------------------
+
+def _stub_broker(monkeypatch, values=None, errors=None, exc=None):
+    """Replace plugin._broker_resolve_http. values: {'service/key': value}."""
+    calls = []
+
+    def fake(origin, token, service, key, timeout):
+        calls.append({"origin": origin, "token": token, "ref": f"{service}/{key}"})
+        if exc is not None:
+            raise exc
+        ref = f"{service}/{key}"
+        if errors and ref in errors:
+            message, status = errors[ref]
+            return None, message, status
+        if values and ref in values:
+            return values[ref], None, 200
+        return None, f"No credential found for {ref}", 404
+
+    monkeypatch.setattr(plugin, "_broker_resolve_http", fake)
+    return calls
+
+
+def test_fetch_resolves_bindings(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_URL", "http://127.0.0.1:8585")
+    calls = _stub_broker(monkeypatch, values={
+        "github/token": "ghp_real", "supabase/db_url": "postgres://real",
+    })
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({
+        "GITHUB_TOKEN": "aquaman://github/token",
+        "DATABASE_URL": "aquaman://supabase/db_url",
+    }), Path("/tmp"))
+    assert result.ok
+    assert result.secrets == {"GITHUB_TOKEN": "ghp_real", "DATABASE_URL": "postgres://real"}
+    assert result.warnings == []
+    assert all(c["origin"] == "http://127.0.0.1:8585" and c["token"] == TOKEN for c in calls)
+
+
+def test_fetch_not_configured_without_env_map(hermes_base):
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg(), Path("/tmp"))
+    assert not result.ok
+    assert result.error_kind.value == "not_configured"
+    assert "secrets.aquaman.env" in result.error
+
+
+def test_fetch_not_configured_without_token(hermes_base, monkeypatch):
+    _stub_broker(monkeypatch)
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({"X": "aquaman://github/token"}), Path("/tmp"))
+    assert not result.ok
+    assert result.error_kind.value == "not_configured"
+    assert "aquaman hermes setup" in result.error
+
+
+def test_fetch_refuses_provider_isolated_vars(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    calls = _stub_broker(monkeypatch, values={"github/token": "ghp_real"})
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({
+        "ANTHROPIC_API_KEY": "aquaman://anthropic/api_key",
+        "OPENAI_API_KEY": "aquaman://openai/api_key",
+        "GITHUB_TOKEN": "aquaman://github/token",
+    }), Path("/tmp"))
+    assert result.ok
+    # LLM keys never materialize into Hermes' env — loopback proxy path only.
+    assert set(result.secrets) == {"GITHUB_TOKEN"}
+    assert sum("process-isolated" in w for w in result.warnings) == 2
+    assert all("anthropic/api_key" not in c["ref"] for c in calls)
+
+
+def test_fetch_skips_invalid_refs_and_names(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    _stub_broker(monkeypatch, values={"github/token": "ghp_real"})
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({
+        "GOOD": "aquaman://github/token",
+        "BAD_REF": "op://vault/item",
+        "1BADNAME": "aquaman://github/token",
+    }), Path("/tmp"))
+    assert result.ok
+    assert set(result.secrets) == {"GOOD"}
+    assert any("invalid ref" in w for w in result.warnings)
+    assert any("invalid env var name" in w for w in result.warnings)
+
+
+def test_fetch_missing_credential_is_per_ref_warning(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    _stub_broker(monkeypatch, values={"github/token": "ghp_real"})
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({
+        "GITHUB_TOKEN": "aquaman://github/token",
+        "MISSING": "aquaman://nope/key",
+    }), Path("/tmp"))
+    # One bad ref never sinks the rest.
+    assert result.ok
+    assert result.secrets == {"GITHUB_TOKEN": "ghp_real"}
+    assert any("nope/key" in w for w in result.warnings)
+
+
+def test_fetch_auth_failure_is_fatal(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", "wrong-token")
+    _stub_broker(monkeypatch, errors={"github/token": ("Loopback request rejected", 401)})
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({"GITHUB_TOKEN": "aquaman://github/token"}), Path("/tmp"))
+    assert not result.ok
+    assert result.error_kind.value == "auth_failed"
+    assert "aquaman hermes setup" in result.error
+
+
+def test_fetch_proxy_down_is_fatal_network(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    _stub_broker(monkeypatch, exc=urllib.error.URLError(ConnectionRefusedError(61, "refused")))
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({"GITHUB_TOKEN": "aquaman://github/token"}), Path("/tmp"))
+    assert not result.ok
+    assert result.error_kind.value == "network"
+    assert "aquaman daemon" in result.error
+
+
+def test_fetch_timeout_maps_to_timeout_kind(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    _stub_broker(monkeypatch, exc=urllib.error.URLError(TimeoutError()))
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({"GITHUB_TOKEN": "aquaman://github/token"}), Path("/tmp"))
+    assert not result.ok
+    assert result.error_kind.value == "timeout"
+
+
+def test_fetch_empty_value_skipped_with_warning(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    _stub_broker(monkeypatch, values={"github/token": ""})
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({"GITHUB_TOKEN": "aquaman://github/token"}), Path("/tmp"))
+    assert result.ok
+    assert result.secrets == {}
+    assert any("empty value" in w for w in result.warnings)
+
+
+def test_fetch_never_raises(hermes_base, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    _stub_broker(monkeypatch, exc=ValueError("unexpected bug"))
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg({"GITHUB_TOKEN": "aquaman://github/token"}), Path("/tmp"))
+    assert not result.ok
+    assert result.error_kind.value == "internal"
+
+
+def test_fetch_defensive_on_malformed_cfg(hermes_base):
+    source = plugin.build_secret_source()
+    for bad in (None, "nope", 42, ["list"]):
+        result = source.fetch(bad, Path("/tmp"))
+        assert not result.ok
+        assert result.error_kind.value == "not_configured"
+
+
+# ---------------------------------------------------------------------------
+# Precedence / protection hooks
+# ---------------------------------------------------------------------------
+
+def test_override_existing_defaults_true(hermes_base):
+    source = plugin.build_secret_source()
+    assert source.override_existing({}) is True
+    assert source.override_existing({"override_existing": False}) is False
+
+
+def test_protected_env_vars_includes_token(hermes_base):
+    source = plugin.build_secret_source()
+    assert "AQUAMAN_LOOPBACK_TOKEN" in source.protected_env_vars({})
+    assert "MY_TOKEN" in source.protected_env_vars({"token_env": "MY_TOKEN"})
+
+
+def test_protected_env_vars_covers_wired_placeholders(hermes_base, monkeypatch):
+    # ANTHROPIC wired through the loopback → its placeholder key var is
+    # protected from ANY source overwriting it with a real key.
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:8585/anthropic")
+    source = plugin.build_secret_source()
+    protected = source.protected_env_vars({})
+    assert "ANTHROPIC_API_KEY" in protected
+    assert "OPENAI_API_KEY" not in protected  # openai not wired here
+
+
+def test_protected_env_vars_ignores_non_loopback_base_urls(hermes_base, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+    source = plugin.build_secret_source()
+    assert "ANTHROPIC_API_KEY" not in source.protected_env_vars({})
+
+
+# ---------------------------------------------------------------------------
+# _broker_resolve_http against a real local HTTP server
+# ---------------------------------------------------------------------------
+
+class _BrokerHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        if self.headers.get("x-aquaman-token") != TOKEN:
+            self._reply(401, {"error": "Loopback request rejected", "fix": "aquaman hermes status"})
+        elif body["service"] == "github":
+            self._reply(200, {"value": "ghp_live_value", "expires_at": "2026-01-01T00:00:00Z"})
+        else:
+            self._reply(404, {"error": f"No credential found for {body['service']}/{body['key']}",
+                              "fix": f"Run: aquaman credentials add {body['service']} {body['key']}"})
+
+    def _reply(self, status, payload):
+        data = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *args):  # keep test output quiet
+        pass
+
+
+@pytest.fixture()
+def broker_server():
+    server = HTTPServer(("127.0.0.1", 0), _BrokerHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+    thread.join(timeout=2)
+
+
+def test_broker_resolve_http_success(broker_server):
+    value, error, status = plugin._broker_resolve_http(broker_server, TOKEN, "github", "token", 2.0)
+    assert (value, error, status) == ("ghp_live_value", None, 200)
+
+
+def test_broker_resolve_http_not_found(broker_server):
+    value, error, status = plugin._broker_resolve_http(broker_server, TOKEN, "nope", "key", 2.0)
+    assert value is None
+    assert status == 404
+    assert "No credential found" in error and "fix:" in error
+
+
+def test_broker_resolve_http_bad_token(broker_server):
+    value, error, status = plugin._broker_resolve_http(broker_server, "bad", "github", "token", 2.0)
+    assert value is None
+    assert status == 401
+
+
+def test_end_to_end_fetch_against_real_server(hermes_base, broker_server, monkeypatch):
+    monkeypatch.setenv("AQUAMAN_LOOPBACK_TOKEN", TOKEN)
+    source = plugin.build_secret_source()
+    result = source.fetch(_cfg(
+        {"GITHUB_TOKEN": "aquaman://github/token"}, base_url=broker_server,
+    ), Path("/tmp"))
+    assert result.ok
+    assert result.secrets == {"GITHUB_TOKEN": "ghp_live_value"}

--- a/packages/hermes/uv.lock
+++ b/packages/hermes/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "aquaman-hermes"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -46,7 +46,7 @@ openclaw                                          # 3. done - proxy starts autom
 
 The `aquaman-proxy` binary is bundled as an exact-pinned npm dependency - no separate download or install needed.
 
-> **Using npm directly?** `npm install -g aquaman-proxy && aquaman openclaw setup` does the same thing - installs the proxy CLI, stores your keys, installs the plugin into `~/.openclaw/extensions/aquaman-plugin/`, and writes the auth-profiles.json placeholder.
+> **Using npm directly?** `npm install -g aquaman-proxy && aquaman openclaw setup` does the same thing - installs the proxy CLI, stores your keys, installs the plugin into `~/.openclaw/extensions/aquaman-plugin/`, and wires the credentials (SecretRef refs on OpenClaw ≥ 2026.6.5, the auth-profiles.json placeholder on older versions).
 
 Troubleshooting: `openclaw aquaman doctor` (or `aquaman openclaw doctor` from a regular shell).
 
@@ -64,11 +64,16 @@ Aquaman keeps API credentials out of the agent process by running them in a sepa
 - Only services listed in the plugin's `services` config get their traffic redirected to the local proxy. As of v0.11.4, the interceptor filters its known-host map by your `services` list. Channels you didn't opt into keep talking to the upstream directly.
 - The interceptor uses a Unix Domain Socket (no TCP, no network exposure). UDS file permissions are `chmod 0o600`, enforced explicitly at proxy startup (v0.12.0+).
 
-**Auth profiles**
+**Credential wiring — SecretRef (v0.14.0+, OpenClaw ≥ 2026.6.5)**
 
-- On load the plugin writes `~/.openclaw/agents/<id>/agent/auth-profiles.json` with placeholder API-key entries for `anthropic` and `openai` so OpenClaw doesn't reject requests before they reach the proxy. The proxy strips the placeholder and injects the real credential.
+- On current OpenClaw, `aquaman openclaw setup` wires the plugin through OpenClaw's canonical **SecretRef** credential surface: the manifest declares an exec resolver (`secretProviderIntegrations.aquaman` → `dist/secrets-resolver.mjs`) and `openclaw.json` gets `models.providers.<svc>.apiKey` refs pointing at it. The resolver returns a static placeholder — real keys stay in your vault; the proxy strips the placeholder and injects the real credential per request.
+- No `openclaw doctor --fix` import step, and the wiring survives OpenClaw's plaintext-scrub flows (`openclaw secrets configure --apply`). `aquaman openclaw doctor` reports the wiring state and suggests the upgrade on legacy installs.
+
+**Auth profiles (legacy path, OpenClaw < 2026.6.5)**
+
+- On load the plugin writes `~/.openclaw/agents/<id>/agent/auth-profiles.json` with placeholder API-key entries for `anthropic` and `openai` so OpenClaw doesn't reject requests before they reach the proxy. The proxy strips the placeholder and injects the real credential. Skipped automatically when the SecretRef wiring is present.
 - The plugin never overwrites an existing `auth-profiles.json`. To suppress generation entirely, set `autoGenerateAuthProfiles: false` in the plugin config (v0.11.4+).
-- **OpenClaw ≥ 2026.6.5:** provider auth profiles moved into each agent's `openclaw-agent.sqlite` and the runtime read path for `auth-profiles.json` was removed ([openclaw/openclaw#89102](https://github.com/openclaw/openclaw/pull/89102)). The placeholder must be imported into SQLite once with `openclaw doctor --fix` (OpenClaw then archives the JSON file). Run `aquaman openclaw doctor`. It detects this and prints the exact remediation.
+- **OpenClaw ≥ 2026.6.5 without SecretRef wiring:** provider auth profiles moved into each agent's `openclaw-agent.sqlite` and the runtime read path for `auth-profiles.json` was removed ([openclaw/openclaw#89102](https://github.com/openclaw/openclaw/pull/89102)). The placeholder must be imported into SQLite once with `openclaw doctor --fix` — or better, re-run `aquaman openclaw setup` to get the SecretRef wiring. Run `aquaman openclaw doctor`; it detects the state and prints the exact remediation.
 
 **Audit log**
 

--- a/packages/plugin/index.ts
+++ b/packages/plugin/index.ts
@@ -315,10 +315,34 @@ function registerStatusTool(api: OpenClawPluginApi, services: string[]): void {
  * `openclaw doctor --fix`, which then archives the file. `aquaman openclaw
  * doctor` detects this and points the operator at the import step. We can't run
  * that import from plugin load — the process-launching module is isolated to
- * proxy-manager.ts to keep the OpenClaw security scanner clean. Holistic fix
- * (SecretRef provider manifest) is tracked for the next plugin touch; see
- * ROADMAP.md.
+ * proxy-manager.ts to keep the OpenClaw security scanner clean.
+ *
+ * v0.14.0+: on gateways with the SecretRef wiring in openclaw.json (written by
+ * `aquaman openclaw setup` on >= 2026.6.5), this whole surface is legacy — the
+ * manifest's secretProviderIntegrations resolver supplies the placeholder via
+ * the canonical SecretRef path, so generation is skipped entirely.
  */
+
+/**
+ * True when openclaw.json already carries the aquaman SecretRef provider
+ * wiring (secrets.providers.aquaman → this plugin's exec integration).
+ * Deliberately a local fs read, not an aquaman-proxy import — keeps the
+ * plugin entry free of anything the OpenClaw security scanner flags.
+ */
+function secretRefWiringPresent(stateDir: string): boolean {
+  try {
+    const raw = fs.readFileSync(path.join(stateDir, "openclaw.json"), "utf-8");
+    const config = JSON.parse(raw);
+    const provider = config?.secrets?.providers?.aquaman;
+    return (
+      provider?.source === "exec" &&
+      provider?.pluginIntegration?.pluginId === "aquaman-plugin"
+    );
+  } catch {
+    return false;
+  }
+}
+
 function ensureAuthProfiles(log: OpenClawPluginApi["logger"], services: string[]): void {
   const stateDir =
     process.env.OPENCLAW_STATE_DIR ||
@@ -330,6 +354,13 @@ function ensureAuthProfiles(log: OpenClawPluginApi["logger"], services: string[]
     "agent",
     "auth-profiles.json"
   );
+
+  if (secretRefWiringPresent(stateDir)) {
+    log.info(
+      "SecretRef wiring active — skipping legacy auth-profiles.json generation"
+    );
+    return;
+  }
 
   if (fs.existsSync(profilesPath)) return;
 

--- a/packages/plugin/openclaw.plugin.json
+++ b/packages/plugin/openclaw.plugin.json
@@ -12,6 +12,18 @@
     "global:override": ["fetch"],
     "fs:write": ["~/.openclaw/agents/*/agent/auth-profiles.json"]
   },
+  "nonSecretAuthMarkers": ["aquaman-proxy-managed"],
+  "secretProviderIntegrations": {
+    "aquaman": {
+      "providerAlias": "aquaman",
+      "displayName": "Aquaman credential proxy",
+      "description": "Resolves provider credentials to the aquaman placeholder marker. Real keys stay in your vault; the aquaman proxy strips the placeholder and injects the real credential upstream — keys never enter the gateway process.",
+      "source": "exec",
+      "command": "${node}",
+      "args": ["./dist/secrets-resolver.mjs"],
+      "timeoutMs": 5000
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Protect API keys and secrets for OpenClaw. Credentials stay in your vault, never in the agent's memory",
   "type": "module",
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && cp secrets-resolver.mjs dist/secrets-resolver.mjs",
     "prepublishOnly": "npm run clean && npm run build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },

--- a/packages/plugin/secrets-resolver.mjs
+++ b/packages/plugin/secrets-resolver.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * SecretRef exec resolver for the aquaman OpenClaw plugin (v0.14.0+).
+ *
+ * Speaks the OpenClaw secret-provider exec protocol (protocolVersion 1,
+ * verified against openclaw 2026.6.10 `resolveExecRefs`/`runExecResolver`):
+ *   stdin:  {"protocolVersion":1,"provider":"aquaman","ids":["anthropic/api_key",...]}
+ *   stdout: {"protocolVersion":1,"values":{"<id>":"<value>",...},"errors":{...}}
+ *
+ * It returns the STATIC placeholder for every requested id — deliberately.
+ * Real keys live in the aquaman vault; the proxy strips whatever key the
+ * gateway presents and injects the real credential upstream. The SecretRef
+ * only needs to resolve to a stable non-empty marker, and resolution must
+ * succeed even when the aquaman daemon isn't running yet (the gateway
+ * resolves its secrets snapshot eagerly at startup) — so this script
+ * contacts nothing: no vault, no proxy, no network, no env reads.
+ *
+ * The gateway spawns it as `${node} ./dist/secrets-resolver.mjs` with an
+ * EMPTY child env (no passEnv declared in the manifest) inside the plugin
+ * root, entrypoint permission-checked. Keep this file dependency-free.
+ */
+
+const PLACEHOLDER = 'aquaman-proxy-managed';
+const PROTOCOL_VERSION = 1;
+
+function fail(message) {
+  process.stderr.write(`aquaman secrets-resolver: ${message}\n`);
+  process.exit(1);
+}
+
+async function main() {
+  let raw = '';
+  for await (const chunk of process.stdin) {
+    raw += chunk;
+    if (raw.length > 256 * 1024) fail('request exceeds 256 KiB');
+  }
+
+  let request;
+  try {
+    request = JSON.parse(raw);
+  } catch (err) {
+    fail(`stdin is not valid JSON: ${err.message}`);
+  }
+
+  if (request.protocolVersion !== PROTOCOL_VERSION) {
+    fail(`unsupported protocolVersion: ${JSON.stringify(request.protocolVersion)} (expected ${PROTOCOL_VERSION})`);
+  }
+
+  const ids = Array.isArray(request.ids) ? request.ids : [];
+  const values = {};
+  const errors = {};
+  for (const id of ids) {
+    if (typeof id === 'string' && id.length > 0) {
+      values[id] = PLACEHOLDER;
+    } else {
+      errors[String(id)] = { message: 'invalid ref id (expected a non-empty string like "anthropic/api_key")' };
+    }
+  }
+
+  const response = { protocolVersion: PROTOCOL_VERSION, values };
+  if (Object.keys(errors).length > 0) response.errors = errors;
+  process.stdout.write(JSON.stringify(response));
+}
+
+main().catch((err) => fail(err && err.message ? err.message : String(err)));

--- a/packages/proxy/src/cli/index.ts
+++ b/packages/proxy/src/cli/index.ts
@@ -37,6 +37,7 @@ import { fileURLToPath } from 'node:url';
 import { createCredentialProxy } from '../daemon.js';
 import { createServiceRegistry, ServiceRegistry } from '../service-registry.js';
 import { createOpenClawIntegration, authProfilesAreSqliteOnly } from '../openclaw/integration.js';
+import { supportsSecretRefIntegrations, wireSecretRefProviders, secretRefWiringStatus } from '../openclaw/secretref.js';
 import { createHermesIntegration, detectHermes } from '../hermes/integration.js';
 import { managedScopeShadowedKeys, HERMES_MANAGED_ENV_PATH } from '../hermes/config-writer.js';
 import { loadPolicyFromConfig, validatePolicyConfig, getDefaultPolicyPresets, matchPolicy, type ServicePolicy } from '../request-policy.js';
@@ -1693,25 +1694,57 @@ openclaw
             openclawConfig.plugins.allow.push('aquaman-plugin');
           }
 
+          const configuredServices = storedServices.length > 0 ? storedServices : ['anthropic', 'openai'];
           openclawConfig.plugins.entries['aquaman-plugin'] = {
             enabled: true,
             config: {
               backend,
-              services: storedServices.length > 0 ? storedServices : ['anthropic', 'openai'],
+              services: configuredServices,
             }
           };
+
+          // Detect the gateway version once \u2014 it gates the credential surface:
+          // SecretRef wiring (canonical, >= 2026.6.5) vs the legacy
+          // auth-profiles.json placeholder. AQUAMAN_OPENCLAW_VERSION overrides
+          // detection (tests + operators pinning behavior explicitly).
+          let ocVersion: string | null = process.env.AQUAMAN_OPENCLAW_VERSION || null;
+          if (!ocVersion) {
+            try {
+              const { execSync } = await import('node:child_process');
+              ocVersion = execSync('openclaw --version', { stdio: 'pipe', encoding: 'utf-8', timeout: 5000 }).trim();
+            } catch { /* CLI not on PATH */ }
+          }
+
+          // b2. SecretRef provider wiring (v0.14.0+, OpenClaw >= 2026.6.5).
+          // Config-level refs in openclaw.json are runtime-read on every
+          // version and survive OpenClaw's plaintext scrubs \u2014 no SQLite
+          // import step needed, unlike the legacy placeholder.
+          const secretRefSupported = supportsSecretRefIntegrations(ocVersion);
+          if (secretRefSupported) {
+            const wiring = wireSecretRefProviders(openclawConfig, configuredServices);
+            if (wiring.wiredProviders.length > 0) {
+              console.log(`  \u2713 SecretRef wiring for ${wiring.wiredProviders.join(', ')} (canonical credential surface)`);
+            }
+            const userKept = wiring.skippedProviders.filter(s => s === 'anthropic' || s === 'openai');
+            if (userKept.length > 0) {
+              console.log(`  \u2192 Left existing user-set apiKey untouched for: ${userKept.join(', ')}`);
+            }
+          }
 
           fs.writeFileSync(openclawJsonPath, JSON.stringify(openclawConfig, null, 2), 'utf-8');
           console.log('  \u2713 Plugin config written to ' + openclawJsonPath);
 
-          // c. Generate auth-profiles.json (only if missing)
+          // c. Generate auth-profiles.json (only if missing). With SecretRef
+          // wiring active this is a redundant legacy surface \u2014 skip it so
+          // `openclaw secrets audit` has no plaintext placeholder to flag.
           const profilesPath = path.join(openclawStateDir, 'agents', 'main', 'agent', 'auth-profiles.json');
-          if (!fs.existsSync(profilesPath)) {
+          if (secretRefSupported) {
+            console.log('  \u2192 Legacy auth-profiles.json placeholder skipped (SecretRef wiring replaces it)');
+          } else if (!fs.existsSync(profilesPath)) {
             const profiles: Record<string, any> = {};
             const order: Record<string, string[]> = {};
 
-            const profileServices = storedServices.length > 0 ? storedServices : ['anthropic', 'openai'];
-            for (const svc of profileServices) {
+            for (const svc of configuredServices) {
               if (svc === 'anthropic' || svc === 'openai') {
                 profiles[`${svc}:default`] = {
                   type: 'api_key',
@@ -1729,19 +1762,13 @@ openclaw
 
             // OpenClaw >= 2026.6.5 reads provider auth profiles from each agent's
             // openclaw-agent.sqlite, not auth-profiles.json (openclaw/openclaw#89102).
-            // The placeholder above must be imported into SQLite once with
-            // `openclaw doctor --fix`. We deliberately do NOT auto-run that here:
+            // On those versions the SecretRef branch above applies instead; this
+            // hint only fires when the version couldn't be detected (SecretRef
+            // gate returned false) but the runtime turns out to be >= 2026.6.5.
+            // We deliberately do NOT auto-run `openclaw doctor --fix` here:
             // it is OpenClaw's broad config-healing command \u2014 verified to take
             // ~19s (gateway probes) and to rewrite openclaw.json (it reset our
-            // plugin entry to bundled defaults in testing). `aquaman openclaw
-            // doctor` detects the SQLite-only case and prints the import step so
-            // the operator runs it intentionally. Holistic fix (SecretRef
-            // provider manifest) is tracked for the next plugin touch.
-            let ocVersion: string | null = null;
-            try {
-              const { execSync } = await import('node:child_process');
-              ocVersion = execSync('openclaw --version', { stdio: 'pipe', encoding: 'utf-8', timeout: 5000 }).trim();
-            } catch { /* CLI not on PATH */ }
+            // plugin entry to bundled defaults in testing).
             if (authProfilesAreSqliteOnly(ocVersion)) {
               console.log('  \u2192 OpenClaw \u2265 2026.6.5 reads auth profiles from SQLite; import the placeholder once:');
               console.log('      openclaw doctor --fix    (backs up openclaw.json first; see aquaman openclaw doctor)');
@@ -1985,9 +2012,10 @@ openclaw
       console.log('    \u2192 Run: aquaman setup (or add policy rules to ~/.aquaman/config.yaml)');
     }
 
-    // 6. OpenClaw detection
+    // 6. OpenClaw detection. AQUAMAN_OPENCLAW_VERSION overrides version
+    // detection (tests + operators pinning behavior explicitly).
     let openclawDetected = false;
-    let openclawVersion: string | null = null;
+    let openclawVersion: string | null = process.env.AQUAMAN_OPENCLAW_VERSION || null;
     let cliFound = false;
     try {
       const { execSync } = await import('node:child_process');
@@ -1998,7 +2026,8 @@ openclaw
     if (cliFound) {
       try {
         const { execSync } = await import('node:child_process');
-        const ver = execSync('openclaw --version', { stdio: 'pipe', encoding: 'utf-8', timeout: 5000 }).trim();
+        const ver = openclawVersion ??
+          execSync('openclaw --version', { stdio: 'pipe', encoding: 'utf-8', timeout: 5000 }).trim();
         openclawVersion = ver;
         console.log(`  \u2713 ${aqua('OpenClaw')} installed (${ver})`);
       } catch {
@@ -2076,15 +2105,53 @@ openclaw
         }
       }
 
-      // 9. Auth profiles. OpenClaw >= 2026.6.5 reads provider auth profiles from
-      //    each agent's openclaw-agent.sqlite and no longer reads
-      //    auth-profiles.json at runtime (openclaw/openclaw#89102). On those
-      //    versions the placeholder the plugin writes to the JSON file must be
-      //    imported into SQLite once via `openclaw doctor --fix`.
+      // 8.5. SecretRef provider wiring (v0.14.0+, OpenClaw >= 2026.6.5) — the
+      //      canonical credential surface that replaces the placeholder
+      //      auth-profiles dance.
+      let secretRefFullyWired = false;
+      if (supportsSecretRefIntegrations(openclawVersion) && fs.existsSync(openclawJsonPath)) {
+        try {
+          const openclawConfig = JSON.parse(fs.readFileSync(openclawJsonPath, 'utf-8'));
+          const pluginServices: string[] =
+            openclawConfig.plugins?.entries?.['aquaman-plugin']?.config?.services ?? ['anthropic', 'openai'];
+          const status = secretRefWiringStatus(openclawConfig, pluginServices);
+          if (status.providerConfigured && status.missingProviders.length === 0) {
+            secretRefFullyWired = true;
+            console.log(`  ✓ ${aqua('SecretRef')} wiring active (${status.wiredProviders.join(', ') || 'no providers'})`);
+          } else if (status.providerConfigured) {
+            // Half-migrated: the provider block exists but some providers still
+            // lack refs — a real inconsistency, fail the check.
+            console.log(`  ✗ ${aqua('SecretRef')} wiring incomplete (providers not wired: ${status.missingProviders.join(', ')})`);
+            console.log('    → Run: aquaman openclaw setup   (completes the SecretRef wiring in openclaw.json)');
+            issues++;
+          } else {
+            // Legacy placeholder flow still functional — upgrade suggestion,
+            // not a failure. (OpenClaw's configure-flow scrubs treat the
+            // plaintext placeholder as residue; SecretRef wiring is immune.)
+            console.log(`  → ${aqua('SecretRef')} wiring available on this OpenClaw — run: aquaman openclaw setup`);
+            console.log('    (replaces the legacy plaintext placeholder, which OpenClaw now scrubs by default)');
+          }
+        } catch {
+          // openclaw.json invalid — already reported above
+        }
+      }
+
+      // 9. Auth profiles. With SecretRef wiring active this surface is
+      //    legacy/inert. Otherwise: OpenClaw >= 2026.6.5 reads provider auth
+      //    profiles from each agent's openclaw-agent.sqlite and no longer reads
+      //    auth-profiles.json at runtime (openclaw/openclaw#89102) — the
+      //    placeholder the plugin writes to the JSON file must be imported
+      //    into SQLite once via `openclaw doctor --fix`.
       const agentDir = path.join(openclawStateDir, 'agents', 'main', 'agent');
       const profilesPath = path.join(agentDir, 'auth-profiles.json');
       const sqlitePath = path.join(agentDir, 'openclaw-agent.sqlite');
-      if (authProfilesAreSqliteOnly(openclawVersion)) {
+      if (secretRefFullyWired) {
+        console.log(`  ✓ ${aqua('Auth profiles')} not needed (SecretRef wiring replaces the placeholder flow)`);
+        if (fs.existsSync(profilesPath)) {
+          console.log('    → Optional: the legacy auth-profiles.json placeholder is inert and may be deleted');
+          console.log('      (`openclaw secrets audit` flags its plaintext placeholder as PLAINTEXT_FOUND)');
+        }
+      } else if (authProfilesAreSqliteOnly(openclawVersion)) {
         if (fs.existsSync(profilesPath)) {
           console.log(`  \u2717 ${aqua('Auth profiles')} JSON present but ${openclawVersion} reads from SQLite`);
           console.log('    \u2192 Import the placeholder once: openclaw doctor --fix  (backs up openclaw.json first)');

--- a/packages/proxy/src/hermes/config-writer.ts
+++ b/packages/proxy/src/hermes/config-writer.ts
@@ -54,6 +54,13 @@ export function generateHermesEnv(config: HermesEnvConfig): Record<string, strin
   const base = `http://${host}:${config.port}`;
   const env: Record<string, string> = {};
 
+  // Always wire the loopback origin + token explicitly. The Hermes secret
+  // source (aquaman-hermes plugin, Hermes >= 0.18.1) reads these to resolve
+  // `aquaman://service/key` bindings via the token-gated /broker/resolve
+  // endpoint — independent of which providers are proxied below.
+  env['AQUAMAN_LOOPBACK_URL'] = base;
+  env['AQUAMAN_LOOPBACK_TOKEN'] = config.token;
+
   for (const service of config.services) {
     if (!SAFE_SERVICE_NAME.test(service)) continue;
 

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -50,6 +50,21 @@ export {
   authProfilesAreSqliteOnly
 } from './openclaw/integration.js';
 
+// OpenClaw SecretRef provider-integration wiring (v0.14.0+)
+export {
+  type SecretRefRef,
+  type SecretRefWiringResult,
+  type SecretRefWiringStatus,
+  SECRETREF_PLUGIN_ID,
+  SECRETREF_INTEGRATION_ID,
+  SECRETREF_PROVIDER_ALIAS,
+  SECRETREF_SUPPORTED_PROVIDERS,
+  supportsSecretRefIntegrations,
+  buildProviderRef,
+  wireSecretRefProviders,
+  secretRefWiringStatus
+} from './openclaw/secretref.js';
+
 // Hermes Integration (v0.13.0+)
 export {
   type HermesEnvConfig,

--- a/packages/proxy/src/openclaw/secretref.ts
+++ b/packages/proxy/src/openclaw/secretref.ts
@@ -1,0 +1,176 @@
+/**
+ * OpenClaw SecretRef provider-integration wiring (v0.14.0+).
+ *
+ * OpenClaw's canonical credential surface is the SecretRef (upstream
+ * openclaw/openclaw#82326, shipped 2026-05-29; docs call auth-profiles.json
+ * "not a runtime format"). The aquaman plugin declares a
+ * `secretProviderIntegrations.aquaman` exec resolver in its manifest
+ * (`packages/plugin/openclaw.plugin.json` → `dist/secrets-resolver.mjs`),
+ * and this module writes the config side into `~/.openclaw/openclaw.json`:
+ *
+ *   secrets.providers.aquaman = {
+ *     source: "exec",
+ *     pluginIntegration: { pluginId: "aquaman-plugin", integrationId: "aquaman" }
+ *   }
+ *   models.providers.<svc>.apiKey = { source: "exec", provider: "aquaman", id: "<svc>/api_key" }
+ *
+ * Config-level refs are used deliberately instead of auth-profile
+ * keyRef/tokenRef: openclaw.json is runtime-read on every version, so this
+ * avoids the SQLite ingestion step (`openclaw doctor --fix`) that the legacy
+ * placeholder flow requires on ≥ 2026.6.5 — and SecretRefs survive the
+ * configure-flow scrubs (`scrubAuthProfilesForProviderTargets` deletes
+ * plaintext keys but preserves valid refs).
+ *
+ * The resolver returns the static `aquaman-proxy-managed` placeholder; the
+ * proxy strips whatever key the gateway presents and injects the real
+ * credential upstream. Keys never enter the gateway process — the SecretRef
+ * integration changes how the *placeholder* reaches the gateway, not the
+ * isolation boundary.
+ */
+
+import { parseCalendarVersion } from './integration.js';
+
+export const SECRETREF_PLUGIN_ID = 'aquaman-plugin';
+export const SECRETREF_INTEGRATION_ID = 'aquaman';
+export const SECRETREF_PROVIDER_ALIAS = 'aquaman';
+
+/** Providers the exec resolver serves refs for today. */
+export const SECRETREF_SUPPORTED_PROVIDERS = ['anthropic', 'openai'] as const;
+
+/**
+ * SecretRef provider integrations shipped with the 2026.6.x line (merged
+ * upstream 2026-05-29). 2026.6.5 is the safe floor — it is also the
+ * auth-profiles→SQLite boundary (`authProfilesAreSqliteOnly`), so on every
+ * version where the legacy JSON placeholder stopped being runtime-read,
+ * SecretRef wiring is available as the replacement. Unknown/unparseable
+ * versions return false (conservative: keep the legacy flow).
+ */
+export function supportsSecretRefIntegrations(version: string | undefined | null): boolean {
+  const parts = parseCalendarVersion(version);
+  if (!parts) return false;
+  const [y, m, d] = parts;
+  if (y !== 2026) return y > 2026;
+  if (m !== 6) return m > 6;
+  return d >= 5;
+}
+
+export interface SecretRefRef {
+  source: 'exec';
+  provider: string;
+  id: string;
+}
+
+export function buildProviderRef(service: string): SecretRefRef {
+  return { source: 'exec', provider: SECRETREF_PROVIDER_ALIAS, id: `${service}/api_key` };
+}
+
+function isAquamanRef(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as SecretRefRef).source === 'exec' &&
+    (value as SecretRefRef).provider === SECRETREF_PROVIDER_ALIAS
+  );
+}
+
+export interface SecretRefWiringResult {
+  changed: boolean;
+  /** Providers whose apiKey now points at the aquaman SecretRef. */
+  wiredProviders: string[];
+  /** Providers requested but skipped (unsupported by the resolver today). */
+  skippedProviders: string[];
+}
+
+/**
+ * Merge the aquaman SecretRef wiring into a parsed openclaw.json object.
+ * Mutates `config` in place (mirrors the CLI's existing merge style),
+ * idempotent, and never overwrites a provider apiKey the user set to
+ * something other than an aquaman ref or the legacy placeholder.
+ */
+export function wireSecretRefProviders(
+  config: Record<string, any>,
+  services: string[]
+): SecretRefWiringResult {
+  let changed = false;
+  const wiredProviders: string[] = [];
+  const skippedProviders: string[] = [];
+
+  if (!config.secrets) config.secrets = {};
+  if (!config.secrets.providers) config.secrets.providers = {};
+  const desiredProvider = {
+    source: 'exec',
+    pluginIntegration: {
+      pluginId: SECRETREF_PLUGIN_ID,
+      integrationId: SECRETREF_INTEGRATION_ID,
+    },
+  };
+  const existingProvider = config.secrets.providers[SECRETREF_PROVIDER_ALIAS];
+  if (JSON.stringify(existingProvider) !== JSON.stringify(desiredProvider)) {
+    config.secrets.providers[SECRETREF_PROVIDER_ALIAS] = desiredProvider;
+    changed = true;
+  }
+
+  for (const service of services) {
+    if (!(SECRETREF_SUPPORTED_PROVIDERS as readonly string[]).includes(service)) {
+      skippedProviders.push(service);
+      continue;
+    }
+    if (!config.models) config.models = {};
+    if (!config.models.providers) config.models.providers = {};
+    if (!config.models.providers[service]) config.models.providers[service] = {};
+
+    const providerEntry = config.models.providers[service];
+    const desiredRef = buildProviderRef(service);
+    const current = providerEntry.apiKey;
+
+    const isLegacyPlaceholder = current === 'aquaman-proxy-managed';
+    const isUserValue =
+      current !== undefined && !isLegacyPlaceholder && !isAquamanRef(current);
+
+    if (isUserValue) {
+      // A key the user set themselves — never clobber it.
+      skippedProviders.push(service);
+      continue;
+    }
+    if (JSON.stringify(current) !== JSON.stringify(desiredRef)) {
+      providerEntry.apiKey = desiredRef;
+      changed = true;
+    }
+    wiredProviders.push(service);
+  }
+
+  return { changed, wiredProviders, skippedProviders };
+}
+
+export interface SecretRefWiringStatus {
+  /** secrets.providers.aquaman points at the plugin integration. */
+  providerConfigured: boolean;
+  /** Providers whose apiKey is an aquaman SecretRef. */
+  wiredProviders: string[];
+  /** Requested + supported providers not yet wired. */
+  missingProviders: string[];
+}
+
+/** Read-only status check for `aquaman openclaw doctor`. */
+export function secretRefWiringStatus(
+  config: Record<string, any>,
+  services: string[]
+): SecretRefWiringStatus {
+  const provider = config?.secrets?.providers?.[SECRETREF_PROVIDER_ALIAS];
+  const providerConfigured =
+    provider?.source === 'exec' &&
+    provider?.pluginIntegration?.pluginId === SECRETREF_PLUGIN_ID &&
+    provider?.pluginIntegration?.integrationId === SECRETREF_INTEGRATION_ID;
+
+  const wiredProviders: string[] = [];
+  const missingProviders: string[] = [];
+  for (const service of services) {
+    if (!(SECRETREF_SUPPORTED_PROVIDERS as readonly string[]).includes(service)) continue;
+    if (isAquamanRef(config?.models?.providers?.[service]?.apiKey)) {
+      wiredProviders.push(service);
+    } else {
+      missingProviders.push(service);
+    }
+  }
+  return { providerConfigured, wiredProviders, missingProviders };
+}

--- a/test/e2e/cli-doctor.test.ts
+++ b/test/e2e/cli-doctor.test.ts
@@ -136,6 +136,67 @@ describe('aquaman doctor E2E', () => {
     }, TEST_TIMEOUT);
   });
 
+  describe('SecretRef wiring (v0.14.0+)', () => {
+    function writeOpenClawJson(env: TempEnv, config: Record<string, any>) {
+      writeFileSync(path.join(env.openclawDir, 'openclaw.json'), JSON.stringify(config, null, 2));
+    }
+    const PLUGIN_ENTRY = {
+      plugins: {
+        allow: ['aquaman-plugin'],
+        entries: { 'aquaman-plugin': { enabled: true, config: { services: ['anthropic', 'openai'] } } },
+      },
+    };
+    const FULL_WIRING = {
+      secrets: {
+        providers: {
+          aquaman: { source: 'exec', pluginIntegration: { pluginId: 'aquaman-plugin', integrationId: 'aquaman' } },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: { apiKey: { source: 'exec', provider: 'aquaman', id: 'anthropic/api_key' } },
+          openai: { apiKey: { source: 'exec', provider: 'aquaman', id: 'openai/api_key' } },
+        },
+      },
+    };
+
+    it('reports active wiring and marks auth profiles as not needed', () => {
+      tempEnv = createTempEnv({ withConfig: true, withPlugin: true });
+      writeOpenClawJson(tempEnv, { ...PLUGIN_ENTRY, ...FULL_WIRING });
+      const { stdout } = runDoctor(tempEnv, { AQUAMAN_OPENCLAW_VERSION: '2026.6.10' });
+
+      expect(stdout).toContain('SecretRef wiring active (anthropic, openai)');
+      expect(stdout).toContain('Auth profiles not needed');
+    }, TEST_TIMEOUT);
+
+    it('suggests (does not fail on) the upgrade when legacy flow is in place', () => {
+      tempEnv = createTempEnv({ withConfig: true, withPlugin: true });
+      writeOpenClawJson(tempEnv, PLUGIN_ENTRY);
+      const { stdout } = runDoctor(tempEnv, { AQUAMAN_OPENCLAW_VERSION: '2026.6.10' });
+
+      expect(stdout).toContain('SecretRef wiring available');
+      expect(stdout).toContain('aquaman openclaw setup');
+    }, TEST_TIMEOUT);
+
+    it('fails on a half-migrated wiring (provider block without refs)', () => {
+      tempEnv = createTempEnv({ withConfig: true, withPlugin: true });
+      writeOpenClawJson(tempEnv, { ...PLUGIN_ENTRY, secrets: FULL_WIRING.secrets });
+      const { stdout, exitCode } = runDoctor(tempEnv, { AQUAMAN_OPENCLAW_VERSION: '2026.6.10' });
+
+      expect(stdout).toContain('SecretRef wiring incomplete');
+      expect(stdout).toContain('providers not wired: anthropic, openai');
+      expect(exitCode).toBe(1);
+    }, TEST_TIMEOUT);
+
+    it('stays silent on gateways below the SecretRef floor', () => {
+      tempEnv = createTempEnv({ withConfig: true, withPlugin: true });
+      writeOpenClawJson(tempEnv, PLUGIN_ENTRY);
+      const { stdout } = runDoctor(tempEnv, { AQUAMAN_OPENCLAW_VERSION: '2026.5.12' });
+
+      expect(stdout).not.toContain('SecretRef');
+    }, TEST_TIMEOUT);
+  });
+
   describe('unmigrated credentials', () => {
     // Commented out: fails on CI (Node 22, macOS + Ubuntu) because the encrypted
     // store populated by a subprocess is not visible to the doctor subprocess.

--- a/test/e2e/cli-setup.test.ts
+++ b/test/e2e/cli-setup.test.ts
@@ -267,3 +267,60 @@ describe('aquaman setup E2E', () => {
     }, TEST_TIMEOUT);
   });
 });
+
+/**
+ * SecretRef wiring branch (v0.14.0+): setup takes the canonical SecretRef
+ * path on gateways >= 2026.6.5 and the legacy auth-profiles placeholder
+ * below that. AQUAMAN_OPENCLAW_VERSION pins the detected version so both
+ * branches are deterministic regardless of what's installed (npx puts
+ * node_modules/.bin — with the real openclaw — first on PATH).
+ */
+describe('aquaman setup SecretRef wiring E2E', () => {
+  let tempEnv: TempEnv;
+
+  beforeEach(() => {
+    tempEnv = createTempEnv({ withOpenClaw: true });
+  });
+
+  afterEach(() => {
+    tempEnv.cleanup();
+  });
+
+  it('wires SecretRef providers and skips the legacy placeholder on >= 2026.6.5', async () => {
+    const { stdout, exitCode } = await runSetup([], { AQUAMAN_OPENCLAW_VERSION: '2026.6.10' }, tempEnv);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('SecretRef wiring for anthropic, openai');
+    expect(stdout).toContain('Legacy auth-profiles.json placeholder skipped');
+
+    const config = JSON.parse(readFileSync(path.join(tempEnv.openclawDir, 'openclaw.json'), 'utf-8'));
+    expect(config.secrets.providers.aquaman).toEqual({
+      source: 'exec',
+      pluginIntegration: { pluginId: 'aquaman-plugin', integrationId: 'aquaman' },
+    });
+    expect(config.models.providers.anthropic.apiKey).toEqual({
+      source: 'exec', provider: 'aquaman', id: 'anthropic/api_key',
+    });
+    expect(config.models.providers.openai.apiKey).toEqual({
+      source: 'exec', provider: 'aquaman', id: 'openai/api_key',
+    });
+
+    const profilesPath = path.join(tempEnv.openclawDir, 'agents', 'main', 'agent', 'auth-profiles.json');
+    expect(existsSync(profilesPath)).toBe(false);
+  }, TEST_TIMEOUT);
+
+  it('keeps the legacy placeholder flow on < 2026.6.5', async () => {
+    const { stdout, exitCode } = await runSetup([], { AQUAMAN_OPENCLAW_VERSION: '2026.5.12' }, tempEnv);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain('SecretRef wiring for');
+
+    const config = JSON.parse(readFileSync(path.join(tempEnv.openclawDir, 'openclaw.json'), 'utf-8'));
+    expect(config.secrets).toBeUndefined();
+
+    const profilesPath = path.join(tempEnv.openclawDir, 'agents', 'main', 'agent', 'auth-profiles.json');
+    expect(existsSync(profilesPath)).toBe(true);
+    const profiles = JSON.parse(readFileSync(profilesPath, 'utf-8'));
+    expect(profiles.profiles['anthropic:default'].key).toBe('aquaman-proxy-managed');
+  }, TEST_TIMEOUT);
+});

--- a/test/e2e/hermes-loopback.test.ts
+++ b/test/e2e/hermes-loopback.test.ts
@@ -152,6 +152,55 @@ describe('Loopback listener E2E (Hermes path)', () => {
     });
   });
 
+  describe('broker over loopback (Hermes secret source, v0.14.0+)', () => {
+    it('resolves a credential with the token', async () => {
+      const res = await fetch(`${baseUrl}/broker/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-aquaman-token': TOKEN },
+        body: JSON.stringify({ service: 'anthropic', key: 'api_key' }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.value).toBe(REAL_ANTHROPIC_KEY);
+      expect(body.expires_at).toBeDefined();
+    });
+
+    it('rejects broker resolution without the token (401)', async () => {
+      const res = await fetch(`${baseUrl}/broker/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ service: 'anthropic', key: 'api_key' }),
+      });
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toContain('token');
+    });
+
+    it('returns 404 with an actionable fix for a missing credential', async () => {
+      const res = await fetch(`${baseUrl}/broker/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-aquaman-token': TOKEN },
+        body: JSON.stringify({ service: 'github', key: 'token' }),
+      });
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.fix).toContain('aquaman credentials add github token');
+    });
+
+    it('audits loopback broker resolves like UDS ones', async () => {
+      requestLog.length = 0;
+      await fetch(`${baseUrl}/broker/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-aquaman-token': TOKEN },
+        body: JSON.stringify({ service: 'anthropic', key: 'api_key' }),
+      });
+      const brokerEvents = requestLog.filter((r) => r.method === 'BROKER');
+      expect(brokerEvents).toHaveLength(1);
+      expect(brokerEvents[0].service).toBe('anthropic');
+      expect(brokerEvents[0].statusCode).toBe(200);
+    });
+  });
+
   describe('UDS listener stays token-free', () => {
     it('serves UDS requests without a loopback token', async () => {
       const res = await udsFetch(socketPath, '/anthropic/v1/messages', {

--- a/test/unit/coder-hook.test.ts
+++ b/test/unit/coder-hook.test.ts
@@ -154,22 +154,116 @@ describe('handlePostToolUse', () => {
     expect(result).toBeNull();
   });
 
-  it('emits additionalContext warning when secrets are found', () => {
+  it('rewrites string output via updatedToolOutput with secrets redacted', () => {
+    const token = 'ghp_' + 'a'.repeat(36);
     const result = handlePostToolUse({
-      tool_response: 'token=ghp_' + 'a'.repeat(36),
+      tool_response: `token=${token} rest-of-line`,
     });
     const out = result?.hookSpecificOutput as any;
     expect(out.hookEventName).toBe('PostToolUse');
-    expect(out.additionalContext).toContain('secret patterns');
+    expect(out.updatedToolOutput).toBe('token=[REDACTED:github-token] rest-of-line');
+    expect(out.updatedToolOutput).not.toContain(token);
     expect(out.additionalContext).toContain('github-token');
   });
 
-  it('handles JSON tool responses', () => {
+  it('deep-redacts structured tool responses preserving their shape', () => {
     const result = handlePostToolUse({
-      tool_response: { stdout: 'AWS_KEY=AKIAIOSFODNN7EXAMPLE\n' },
+      tool_response: {
+        stdout: 'AWS_KEY=AKIAIOSFODNN7EXAMPLE\n',
+        lines: ['clean', 'sk-ant-' + 'b'.repeat(40)],
+        exitCode: 0,
+      },
     });
-    expect(result).not.toBeNull();
     const out = result?.hookSpecificOutput as any;
     expect(out.additionalContext).toContain('aws-access-key-id');
+    expect(out.updatedToolOutput).toEqual({
+      stdout: 'AWS_KEY=[REDACTED:aws-access-key-id]\n',
+      lines: ['clean', '[REDACTED:anthropic-key]'],
+      exitCode: 0,
+    });
+  });
+
+  it('falls back to warning-only when output rewriting is disabled', () => {
+    const result = handlePostToolUse(
+      { tool_response: 'token=ghp_' + 'a'.repeat(36) },
+      { disableOutputRewrite: true }
+    );
+    const out = result?.hookSpecificOutput as any;
+    expect(out.hookEventName).toBe('PostToolUse');
+    expect(out.updatedToolOutput).toBeUndefined();
+    expect(out.additionalContext).toContain('secret patterns');
+    expect(out.additionalContext).toContain('aquaman-coder exec');
+  });
+});
+
+/**
+ * Claude Code 2.1.210 fixed exit-2 handling when a hook's stdout JSON
+ * fails schema validation — malformed hook output now surfaces instead
+ * of being silently ignored. Lock down that every decision we emit is
+ * strictly schema-shaped: known fields only, correct types, hookEventName
+ * matching the event.
+ */
+describe('hook output schema validity (Claude Code ≥2.1.210)', () => {
+  const PRE_FIELDS = new Set([
+    'hookEventName', 'permissionDecision', 'permissionDecisionReason',
+    'updatedInput', 'additionalContext',
+  ]);
+  const POST_FIELDS = new Set([
+    'hookEventName', 'additionalContext', 'updatedToolOutput',
+  ]);
+
+  it('PreToolUse decisions carry only documented hookSpecificOutput fields', async () => {
+    const cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aquaman-project-'));
+    const yaml = `projects:
+  my-app:
+    paths: ["${cwdDir}"]
+    env:
+      X: aquaman://anthropic/api_key
+`;
+    for (const healthy of [true, false]) {
+      const { ctx } = ctxWithProjects(yaml, new StubBroker({}, healthy));
+      const result = await handlePreToolUse({
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hi' },
+        cwd: cwdDir,
+      }, ctx);
+      const out = result?.hookSpecificOutput as any;
+      expect(out).toBeDefined();
+      expect(out.hookEventName).toBe('PreToolUse');
+      for (const key of Object.keys(out)) {
+        expect(PRE_FIELDS.has(key), `unexpected PreToolUse field: ${key}`).toBe(true);
+      }
+      expect(['allow', 'deny', 'ask']).toContain(out.permissionDecision);
+      if (out.updatedInput !== undefined) {
+        expect(typeof out.updatedInput).toBe('object');
+        expect(typeof out.updatedInput.command).toBe('string');
+      }
+      fs.rmSync(path.dirname(ctx.projectsPath!), { recursive: true, force: true });
+    }
+    fs.rmSync(cwdDir, { recursive: true, force: true });
+  });
+
+  it('PostToolUse decisions carry only documented hookSpecificOutput fields', () => {
+    for (const ctx of [{}, { disableOutputRewrite: true }]) {
+      const result = handlePostToolUse(
+        { tool_response: 'sk-ant-' + 'c'.repeat(40) },
+        ctx
+      );
+      const out = result?.hookSpecificOutput as any;
+      expect(out.hookEventName).toBe('PostToolUse');
+      for (const key of Object.keys(out)) {
+        expect(POST_FIELDS.has(key), `unexpected PostToolUse field: ${key}`).toBe(true);
+      }
+      expect(typeof out.additionalContext).toBe('string');
+    }
+  });
+
+  it('decisions serialize to valid JSON round-trips (stdout contract)', () => {
+    const decision = handlePostToolUse({
+      tool_response: { nested: { key: 'xoxb-1234567890-abcdef' } },
+    });
+    const serialized = JSON.stringify(decision);
+    expect(() => JSON.parse(serialized)).not.toThrow();
+    expect(JSON.parse(serialized)).toEqual(decision);
   });
 });

--- a/test/unit/hermes/config-writer.test.ts
+++ b/test/unit/hermes/config-writer.test.ts
@@ -31,7 +31,14 @@ describe('generateHermesEnv', () => {
 
   it('ignores unsupported services (channels/other providers)', () => {
     const env = generateHermesEnv({ ...opts, services: ['slack', 'telegram', 'github'] });
-    expect(Object.keys(env)).toHaveLength(0);
+    // Only the always-on loopback wiring remains — no provider vars.
+    expect(Object.keys(env).sort()).toEqual(['AQUAMAN_LOOPBACK_TOKEN', 'AQUAMAN_LOOPBACK_URL']);
+  });
+
+  it('always wires the loopback origin + token for the secret source (v0.14.0+)', () => {
+    const env = generateHermesEnv({ ...opts, services: ['anthropic'] });
+    expect(env['AQUAMAN_LOOPBACK_URL']).toBe('http://127.0.0.1:8585');
+    expect(env['AQUAMAN_LOOPBACK_TOKEN']).toBe('aqm_lb_tok');
   });
 
   it('honors a custom host', () => {

--- a/test/unit/openclaw-secretref.test.ts
+++ b/test/unit/openclaw-secretref.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for the OpenClaw SecretRef provider integration (v0.14.0+).
+ *
+ * Covers:
+ *   - the version gate (SecretRef available >= 2026.6.5)
+ *   - openclaw.json wiring: idempotent merge, user-value preservation,
+ *     legacy-placeholder upgrade, status reporting
+ *   - the exec resolver script's protocol (spawned the way the gateway
+ *     spawns it: `${node} ./dist/secrets-resolver.mjs`, EMPTY child env,
+ *     request on stdin, protocolVersion 1)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+import * as url from 'node:url';
+import {
+  supportsSecretRefIntegrations,
+  buildProviderRef,
+  wireSecretRefProviders,
+  secretRefWiringStatus,
+} from 'aquaman-proxy';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const RESOLVER = path.resolve(__dirname, '../../packages/plugin/secrets-resolver.mjs');
+
+describe('supportsSecretRefIntegrations (version gate)', () => {
+  it.each([
+    ['2026.6.5', true],
+    ['2026.6.10', true],
+    ['2026.7.1', true],
+    ['2027.1.1', true],
+    ['2026.6.4', false],
+    ['2026.5.12', false],
+    ['2025.12.31', false],
+  ])('%s → %s', (version, expected) => {
+    expect(supportsSecretRefIntegrations(version)).toBe(expected);
+  });
+
+  it('is conservative on unknown/unparseable versions', () => {
+    expect(supportsSecretRefIntegrations(undefined)).toBe(false);
+    expect(supportsSecretRefIntegrations(null)).toBe(false);
+    expect(supportsSecretRefIntegrations('not-a-version')).toBe(false);
+    expect(supportsSecretRefIntegrations('')).toBe(false);
+  });
+});
+
+describe('wireSecretRefProviders', () => {
+  it('writes the provider integration and per-service refs into an empty config', () => {
+    const config: Record<string, any> = {};
+    const result = wireSecretRefProviders(config, ['anthropic', 'openai']);
+
+    expect(result.changed).toBe(true);
+    expect(result.wiredProviders).toEqual(['anthropic', 'openai']);
+    expect(config.secrets.providers.aquaman).toEqual({
+      source: 'exec',
+      pluginIntegration: { pluginId: 'aquaman-plugin', integrationId: 'aquaman' },
+    });
+    expect(config.models.providers.anthropic.apiKey).toEqual({
+      source: 'exec', provider: 'aquaman', id: 'anthropic/api_key',
+    });
+    expect(config.models.providers.openai.apiKey).toEqual({
+      source: 'exec', provider: 'aquaman', id: 'openai/api_key',
+    });
+  });
+
+  it('is idempotent — second run reports no change', () => {
+    const config: Record<string, any> = {};
+    wireSecretRefProviders(config, ['anthropic']);
+    const second = wireSecretRefProviders(config, ['anthropic']);
+    expect(second.changed).toBe(false);
+    expect(second.wiredProviders).toEqual(['anthropic']);
+  });
+
+  it('never clobbers a user-set plaintext apiKey', () => {
+    const config: Record<string, any> = {
+      models: { providers: { anthropic: { apiKey: 'sk-ant-users-own-key' } } },
+    };
+    const result = wireSecretRefProviders(config, ['anthropic']);
+    expect(config.models.providers.anthropic.apiKey).toBe('sk-ant-users-own-key');
+    expect(result.wiredProviders).toEqual([]);
+    expect(result.skippedProviders).toContain('anthropic');
+  });
+
+  it('never clobbers a user-set foreign SecretRef', () => {
+    const foreignRef = { source: 'env', provider: 'default', id: 'MY_ANTHROPIC_KEY' };
+    const config: Record<string, any> = {
+      models: { providers: { anthropic: { apiKey: foreignRef } } },
+    };
+    wireSecretRefProviders(config, ['anthropic']);
+    expect(config.models.providers.anthropic.apiKey).toEqual(foreignRef);
+  });
+
+  it('upgrades the legacy literal placeholder to a SecretRef', () => {
+    const config: Record<string, any> = {
+      models: { providers: { anthropic: { apiKey: 'aquaman-proxy-managed' } } },
+    };
+    const result = wireSecretRefProviders(config, ['anthropic']);
+    expect(result.wiredProviders).toEqual(['anthropic']);
+    expect(config.models.providers.anthropic.apiKey).toEqual(buildProviderRef('anthropic'));
+  });
+
+  it('skips services the resolver does not serve, preserving other config', () => {
+    const config: Record<string, any> = { channels: { telegram: { enabled: true } } };
+    const result = wireSecretRefProviders(config, ['anthropic', 'telegram', 'slack']);
+    expect(result.wiredProviders).toEqual(['anthropic']);
+    expect(result.skippedProviders).toEqual(expect.arrayContaining(['telegram', 'slack']));
+    expect(config.channels).toEqual({ telegram: { enabled: true } });
+    expect(config.models.providers.telegram).toBeUndefined();
+  });
+});
+
+describe('secretRefWiringStatus', () => {
+  it('reports fully wired config', () => {
+    const config: Record<string, any> = {};
+    wireSecretRefProviders(config, ['anthropic', 'openai']);
+    const status = secretRefWiringStatus(config, ['anthropic', 'openai']);
+    expect(status.providerConfigured).toBe(true);
+    expect(status.wiredProviders).toEqual(['anthropic', 'openai']);
+    expect(status.missingProviders).toEqual([]);
+  });
+
+  it('reports missing provider block and unwired services', () => {
+    const status = secretRefWiringStatus({}, ['anthropic', 'openai']);
+    expect(status.providerConfigured).toBe(false);
+    expect(status.missingProviders).toEqual(['anthropic', 'openai']);
+  });
+
+  it('ignores non-provider services in the requested list', () => {
+    const config: Record<string, any> = {};
+    wireSecretRefProviders(config, ['anthropic']);
+    const status = secretRefWiringStatus(config, ['anthropic', 'telegram']);
+    expect(status.wiredProviders).toEqual(['anthropic']);
+    expect(status.missingProviders).toEqual([]);
+  });
+});
+
+/**
+ * Exec resolver protocol tests. Spawn conditions mirror the gateway's
+ * `runExecResolver` (openclaw 2026.6.10): request JSON on stdin, stdin
+ * closed, response JSON on stdout, empty child env (the manifest declares
+ * no passEnv), cwd = script dir.
+ */
+describe('secrets-resolver.mjs (exec protocol v1)', () => {
+  function runResolver(input: string): Promise<{ code: number; stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(process.execPath, [RESOLVER], {
+        cwd: path.dirname(RESOLVER),
+        env: {},           // the gateway passes ONLY manifest env + passEnv — we declare neither
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', (d) => { stdout += d; });
+      proc.stderr.on('data', (d) => { stderr += d; });
+      proc.on('error', reject);
+      proc.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+      proc.stdin.write(input);
+      proc.stdin.end();
+    });
+  }
+
+  it('resolves every requested id to the static placeholder', async () => {
+    const { code, stdout } = await runResolver(JSON.stringify({
+      protocolVersion: 1,
+      provider: 'aquaman',
+      ids: ['anthropic/api_key', 'openai/api_key'],
+    }));
+    expect(code).toBe(0);
+    const response = JSON.parse(stdout);
+    expect(response).toEqual({
+      protocolVersion: 1,
+      values: {
+        'anthropic/api_key': 'aquaman-proxy-managed',
+        'openai/api_key': 'aquaman-proxy-managed',
+      },
+    });
+  });
+
+  it('works with an empty child env (no vault, no proxy, no env reads)', async () => {
+    // Isolation property (ATLAS T0055): the resolver is static — even spawned
+    // with nothing in its environment it must succeed, proving it cannot be
+    // exfiltrating real credentials into the gateway process.
+    const { code, stdout } = await runResolver(JSON.stringify({
+      protocolVersion: 1, provider: 'aquaman', ids: ['anthropic/api_key'],
+    }));
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).values['anthropic/api_key']).toBe('aquaman-proxy-managed');
+  });
+
+  it('rejects an unsupported protocolVersion (nonzero exit, stderr)', async () => {
+    const { code, stderr } = await runResolver(JSON.stringify({ protocolVersion: 2, ids: [] }));
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('unsupported protocolVersion');
+  });
+
+  it('rejects malformed JSON on stdin', async () => {
+    const { code, stderr } = await runResolver('{not json');
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('not valid JSON');
+  });
+
+  it('maps invalid ids into the errors object without failing the batch', async () => {
+    const { code, stdout } = await runResolver(JSON.stringify({
+      protocolVersion: 1, provider: 'aquaman', ids: ['anthropic/api_key', '', 42],
+    }));
+    expect(code).toBe(0);
+    const response = JSON.parse(stdout);
+    expect(response.values['anthropic/api_key']).toBe('aquaman-proxy-managed');
+    expect(Object.keys(response.errors).sort()).toEqual(['', '42']);
+  });
+
+  it('handles an empty ids array', async () => {
+    const { code, stdout } = await runResolver(JSON.stringify({
+      protocolVersion: 1, provider: 'aquaman', ids: [],
+    }));
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({ protocolVersion: 1, values: {} });
+  });
+});


### PR DESCRIPTION
## v0.14.0 — Host-Native Credential Surfaces

### 1. OpenClaw SecretRef provider integration (plugin + proxy)

OpenClaw's canonical credential surface is now the SecretRef (#82326); auth-profiles.json is "not a runtime format" and the configure flow scrubs plaintext keys — including our placeholder — by default.

- Manifest declares `secretProviderIntegrations.aquaman` (exec resolver, `${node}` + `dist/secrets-resolver.mjs`) + `nonSecretAuthMarkers`.
- The resolver returns the **static placeholder** (no vault, no proxy, no env reads) — the proxy still strips it and injects the real key upstream, so the isolation boundary is unchanged. Static-by-design: the gateway resolves its secrets snapshot eagerly at startup, possibly before `aquaman daemon` is up.
- `aquaman openclaw setup` writes config-level refs (`secrets.providers.aquaman` + `models.providers.<svc>.apiKey`) on gateways >= 2026.6.5 — no `openclaw doctor --fix` SQLite import step, and refs survive OpenClaw's scrubs. Legacy placeholder flow preserved for older gateways; user-set apiKeys are never clobbered.
- Plugin load skips auth-profiles generation when the wiring is present; doctor reports active / half-migrated (fail) / available (upgrade hint).
- Contract verified against the installed openclaw 2026.6.10 dist (types + resolver semantics) and live docs, incl. the 2026.7.1 secret-sentinel behavior (#102009).

### 2. Hermes secret source (aquaman-hermes + proxy)

Hermes 0.18.1 shipped the official pluggable `SecretSource` contract (`ctx.register_secret_source`); core declines further built-in vault engines — external backends are plugins now.

- `aquaman-hermes` registers an `aquaman` mapped source (hasattr feature-detection; 0.18.0 hosts stay sugar-only). Bindings: `secrets.aquaman.env: { GITHUB_TOKEN: aquaman://github/token }`.
- Resolution via the token-gated loopback `POST /broker/resolve` (already shared between UDS and loopback listeners) — vault-backed, per-read hash-chain audited.
- **Two-tier model enforced in code:** LLM provider keys are refused by the source (loopback proxy path only — a poisoned config.yaml can't downgrade the isolation); project secrets materialize into Hermes' env, documented honestly as residency-not-isolation.
- Contract compliance per `agent/secret_sources/base.py` v1: never raises/prompts/writes os.environ, typed error taxonomy, fail-open startup, no disk cache, token scrubbed from every surfaced string, `protected_env_vars` guards the loopback wiring.
- `~/.hermes/.env` managed block now always includes `AQUAMAN_LOOPBACK_URL`/`AQUAMAN_LOOPBACK_TOKEN`.

### 3. Claude Code PostToolUse output redaction (coder)

- `updatedToolOutput` (>= 2.1.170, verified stable through 2.1.215) adopted: every tool's output is redacted (shape-preserving) before it reaches the transcript — Read/Grep surfacing on-disk secrets, MCP tools, unwrapped Bash. `AQUAMAN_DISABLE_OUTPUT_REWRITE=1` restores warning-only behavior for older hosts.
- Schema-validity regression tests for all hook decisions (Claude Code 2.1.210 made schema-invalid hook stdout consequential).

### 4. CI

- ClawHub publish now stamps `openclaw.install.npmSpec`/`expectedIntegrity` from the published npm tarball's `dist.integrity` (OpenClaw warns when missing). Best-effort, never fails the publish.

### Notes

- OpenClaw CI pin stays at exact 2026.6.10 — 2026.7.1 fixes #98528 but is flagged for gateway crash loops; bump straight to 2026.7.2 stable when it lands.
- Version stamping happens at release time via CD, as usual.
